### PR TITLE
Bug/methods

### DIFF
--- a/lib/apis/auth_api/auth_client.dart
+++ b/lib/apis/auth_api/auth_client.dart
@@ -127,11 +127,13 @@ class AuthClient implements IAuthClient {
   Future<AuthRequestResponse> requestAuth({
     required AuthRequestParams params,
     String? pairingTopic,
+    List<List<String>>? methods = AuthEngine.DEFAULT_METHODS,
   }) async {
     try {
       return engine.requestAuth(
         params: params,
         pairingTopic: pairingTopic,
+        methods: methods,
       );
     } catch (e) {
       rethrow;

--- a/lib/apis/auth_api/auth_engine.dart
+++ b/lib/apis/auth_api/auth_engine.dart
@@ -22,6 +22,12 @@ import 'package:walletconnect_flutter_v2/apis/utils/errors.dart';
 import 'package:walletconnect_flutter_v2/apis/utils/method_constants.dart';
 
 class AuthEngine implements IAuthEngine {
+  static const List<List<String>> DEFAULT_METHODS = [
+    [
+      MethodConstants.WC_AUTH_REQUEST,
+    ]
+  ];
+
   bool _initialized = false;
 
   @override
@@ -74,6 +80,7 @@ class AuthEngine implements IAuthEngine {
   Future<AuthRequestResponse> requestAuth({
     required AuthRequestParams params,
     String? pairingTopic,
+    List<List<String>>? methods = DEFAULT_METHODS,
   }) async {
     _checkInitialized();
 
@@ -82,7 +89,9 @@ class AuthEngine implements IAuthEngine {
     Uri? uri;
 
     if (pTopic == null) {
-      final CreateResponse newTopicAndUri = await core.pairing.create();
+      final CreateResponse newTopicAndUri = await core.pairing.create(
+        methods: methods,
+      );
       pTopic = newTopicAndUri.topic;
       uri = newTopicAndUri.uri;
     } else {

--- a/lib/apis/auth_api/i_auth_engine_app.dart
+++ b/lib/apis/auth_api/i_auth_engine_app.dart
@@ -10,5 +10,6 @@ abstract class IAuthEngineApp extends IAuthEngineCommon {
   Future<AuthRequestResponse> requestAuth({
     required AuthRequestParams params,
     String? pairingTopic,
+    List<List<String>>? methods,
   });
 }

--- a/lib/apis/core/pairing/i_pairing.dart
+++ b/lib/apis/core/pairing/i_pairing.dart
@@ -16,7 +16,9 @@ abstract class IPairing {
     required Uri uri,
     bool activatePairing,
   });
-  Future<CreateResponse> create({List<List<String>> methods});
+  Future<CreateResponse> create({
+    List<List<String>>? methods,
+  });
   Future<void> activate({required String topic});
   void register({
     required String method,

--- a/lib/apis/core/pairing/pairing.dart
+++ b/lib/apis/core/pairing/pairing.dart
@@ -84,7 +84,7 @@ class Pairing implements IPairing {
 
   @override
   Future<CreateResponse> create({
-    List<List<String>> methods = const [],
+    List<List<String>>? methods,
   }) async {
     _checkInitialized();
     final String symKey = core.crypto.getUtils().generateRandomBytes32();

--- a/lib/apis/sign_api/i_sign_engine_app.dart
+++ b/lib/apis/sign_api/i_sign_engine_app.dart
@@ -20,6 +20,7 @@ abstract class ISignEngineApp extends ISignEngineCommon {
     Map<String, String>? sessionProperties,
     String? pairingTopic,
     List<Relay>? relays,
+    List<List<String>>? methods,
   });
   Future<dynamic> request({
     required String topic,

--- a/lib/apis/sign_api/sign_client.dart
+++ b/lib/apis/sign_api/sign_client.dart
@@ -20,6 +20,7 @@ import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_events
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/session_models.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/sessions.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/utils/sign_constants.dart';
+import 'package:walletconnect_flutter_v2/apis/utils/method_constants.dart';
 
 class SignClient implements ISignClient {
   bool _initialized = false;
@@ -129,6 +130,7 @@ class SignClient implements ISignClient {
     Map<String, String>? sessionProperties,
     String? pairingTopic,
     List<Relay>? relays,
+    List<List<String>>? methods = SignEngine.DEFAULT_METHODS,
   }) async {
     try {
       return await engine.connect(
@@ -137,6 +139,7 @@ class SignClient implements ISignClient {
         sessionProperties: sessionProperties,
         pairingTopic: pairingTopic,
         relays: relays,
+        methods: methods,
       );
     } catch (e) {
       // print(e);

--- a/lib/apis/sign_api/sign_client.dart
+++ b/lib/apis/sign_api/sign_client.dart
@@ -20,7 +20,6 @@ import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_events
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/session_models.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/sessions.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/utils/sign_constants.dart';
-import 'package:walletconnect_flutter_v2/apis/utils/method_constants.dart';
 
 class SignClient implements ISignClient {
   bool _initialized = false;

--- a/lib/apis/sign_api/sign_engine.dart
+++ b/lib/apis/sign_api/sign_engine.dart
@@ -25,6 +25,13 @@ import 'package:walletconnect_flutter_v2/apis/utils/method_constants.dart';
 import 'package:walletconnect_flutter_v2/apis/utils/walletconnect_utils.dart';
 
 class SignEngine implements ISignEngine {
+  static const List<List<String>> DEFAULT_METHODS = [
+    [
+      MethodConstants.WC_SESSION_PROPOSE,
+      MethodConstants.WC_SESSION_REQUEST,
+    ],
+  ];
+
   bool _initialized = false;
 
   @override
@@ -97,6 +104,7 @@ class SignEngine implements ISignEngine {
     Map<String, String>? sessionProperties,
     String? pairingTopic,
     List<Relay>? relays,
+    List<List<String>>? methods = DEFAULT_METHODS,
   }) async {
     _checkInitialized();
 
@@ -111,7 +119,9 @@ class SignEngine implements ISignEngine {
     Uri? uri;
 
     if (pTopic == null) {
-      final CreateResponse newTopicAndUri = await core.pairing.create();
+      final CreateResponse newTopicAndUri = await core.pairing.create(
+        methods: methods,
+      );
       pTopic = newTopicAndUri.topic;
       uri = newTopicAndUri.uri;
       // print('connect generated topic: $topic');

--- a/lib/apis/utils/walletconnect_utils.dart
+++ b/lib/apis/utils/walletconnect_utils.dart
@@ -131,11 +131,15 @@ class WalletConnectUtils {
     required String topic,
     required String symKey,
     required Relay relay,
-    required List<List<String>> methods,
+    required List<List<String>>? methods,
   }) {
     Map<String, String> params = formatRelayParams(relay);
     params['symKey'] = symKey;
-    params['methods'] = methods.map((e) => jsonEncode(e)).join(',');
+    if (methods != null) {
+      params['methods'] = methods.map((e) => jsonEncode(e)).join(',');
+    } else {
+      params['methods'] = '[]';
+    }
 
     return Uri(
       scheme: protocol,

--- a/lib/apis/web3app/web3app.dart
+++ b/lib/apis/web3app/web3app.dart
@@ -8,9 +8,20 @@ import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sessions.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/utils/sign_constants.dart';
+import 'package:walletconnect_flutter_v2/apis/utils/method_constants.dart';
 import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
 
 class Web3App implements IWeb3App {
+  static const List<List<String>> DEFAULT_METHODS = [
+    [
+      MethodConstants.WC_SESSION_PROPOSE,
+      MethodConstants.WC_SESSION_REQUEST,
+    ],
+    [
+      MethodConstants.WC_AUTH_REQUEST,
+    ]
+  ];
+
   bool _initialized = false;
 
   static Future<Web3App> createInstance({
@@ -168,6 +179,7 @@ class Web3App implements IWeb3App {
     Map<String, String>? sessionProperties,
     String? pairingTopic,
     List<Relay>? relays,
+    List<List<String>>? methods = DEFAULT_METHODS,
   }) async {
     try {
       return await signEngine.connect(
@@ -176,6 +188,7 @@ class Web3App implements IWeb3App {
         sessionProperties: sessionProperties,
         pairingTopic: pairingTopic,
         relays: relays,
+        methods: methods,
       );
     } catch (e) {
       // print(e);
@@ -274,11 +287,13 @@ class Web3App implements IWeb3App {
   Future<AuthRequestResponse> requestAuth({
     required AuthRequestParams params,
     String? pairingTopic,
+    List<List<String>>? methods = DEFAULT_METHODS,
   }) async {
     try {
       return authEngine.requestAuth(
         params: params,
         pairingTopic: pairingTopic,
+        methods: methods,
       );
     } catch (e) {
       rethrow;

--- a/lib/apis/web3app/web3app.dart
+++ b/lib/apis/web3app/web3app.dart
@@ -8,7 +8,6 @@ import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sessions.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/utils/sign_constants.dart';
-import 'package:walletconnect_flutter_v2/apis/utils/method_constants.dart';
 import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
 
 class Web3App implements IWeb3App {

--- a/lib/walletconnect_flutter_v2.dart
+++ b/lib/walletconnect_flutter_v2.dart
@@ -12,6 +12,8 @@ export 'apis/utils/walletconnect_utils.dart';
 export 'apis/models/json_rpc_error.dart';
 export 'apis/models/json_rpc_response.dart';
 export 'apis/utils/constants.dart';
+export 'apis/models/uri_parse_result.dart';
+export 'apis/utils/method_constants.dart';
 
 // Sign API
 export 'apis/sign_api/i_sign_engine.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: walletconnect_flutter_v2
 description: WalletConnect v2 client made in dart for flutter.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/WalletConnect/WalletConnectDartV2
 
 environment:

--- a/test/auth_api/auth_client_test.dart
+++ b/test/auth_api/auth_client_test.dart
@@ -356,6 +356,40 @@ void runTests({
     });
 
     group('requestAuth', () {
+      test('creates correct URI', () async {
+        AuthRequestResponse response = await clientA.requestAuth(
+          params: testAuthRequestParamsValid,
+        );
+
+        expect(response.uri != null, true);
+        URIParseResult parsed = WalletConnectUtils.parseUri(response.uri!);
+        expect(parsed.protocol, 'wc');
+        expect(parsed.version, '2');
+        expect(parsed.topic, response.pairingTopic);
+        expect(parsed.relay.protocol, 'irn');
+        if (clientA is IWeb3App) {
+          expect(parsed.methods.length, 3);
+          expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+          expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
+          expect(parsed.methods[2], MethodConstants.WC_AUTH_REQUEST);
+        } else {
+          expect(parsed.methods.length, 1);
+          expect(parsed.methods[0], MethodConstants.WC_AUTH_REQUEST);
+        }
+
+        response = await clientA.requestAuth(
+          params: testAuthRequestParamsValid,
+          methods: [],
+        );
+
+        expect(response.uri != null, true);
+        parsed = WalletConnectUtils.parseUri(response.uri!);
+        expect(parsed.protocol, 'wc');
+        expect(parsed.version, '2');
+        expect(parsed.relay.protocol, 'irn');
+        expect(parsed.methods.length, 0);
+      });
+
       test('invalid request params', () async {
         expect(
           () => clientA.requestAuth(

--- a/test/sign_api/sign_client_test.dart
+++ b/test/sign_api/sign_client_test.dart
@@ -332,7 +332,40 @@ void signingEngineTests({
     });
 
     group('connect', () {
-      test('process emits proper events', () async {});
+      test('creates correct URI', () async {
+        ConnectResponse response = await clientA.connect(
+          requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+        );
+
+        expect(response.uri != null, true);
+        URIParseResult parsed = WalletConnectUtils.parseUri(response.uri!);
+        expect(parsed.protocol, 'wc');
+        expect(parsed.version, '2');
+        expect(parsed.topic, response.pairingTopic);
+        expect(parsed.relay.protocol, 'irn');
+        if (clientA is IWeb3App) {
+          expect(parsed.methods.length, 3);
+          expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+          expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
+          expect(parsed.methods[2], MethodConstants.WC_AUTH_REQUEST);
+        } else {
+          expect(parsed.methods.length, 2);
+          expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+          expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
+        }
+
+        response = await clientA.connect(
+          requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+          methods: [],
+        );
+
+        expect(response.uri != null, true);
+        parsed = WalletConnectUtils.parseUri(response.uri!);
+        expect(parsed.protocol, 'wc');
+        expect(parsed.version, '2');
+        expect(parsed.relay.protocol, 'irn');
+        expect(parsed.methods.length, 0);
+      });
 
       test('invalid topic', () {
         expect(


### PR DESCRIPTION
# Description

Add the ability to pass methods list into connect and requestAuth functions.
Also added defaults for both.
Built tests for all URI handling.

Resolves #11 

## How Has This Been Tested?

Added tests to Sign and Auth API unit tests, which will run the test for Sign and Auth client, engine, and Web3App.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update