### PR TITLE
Use the code 6000 instead of 4001 to disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ await wcClient.emitSessionEvent(
 await wcClient.disconnectSession(
   topic: pairing.topic,
   reason: WalletConnectErrorResponse(
-    code: 4001,
+    code: 6000,
     message: 'User disconnected session',
   ),
 );


### PR DESCRIPTION
# Description
Use the code `6000` instead of `4001` to disconnect as it's specified in [this](https://docs.walletconnect.com/2.0/specs/clients/sign/error-codes#reason) document.

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves #15 (issue)

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [x] Requires a documentation update