### PR TITLE
Fixes bug 21 in parent repo

### DIFF
--- a/example/dapp/pubspec.yaml
+++ b/example/dapp/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   qr_flutter: ^4.0.0
-  json_annotation: ^4.7.0
+  json_annotation: ^4.8.0
   # walletconnect_flutter_v2: ^1.0.5
   walletconnect_flutter_v2:
     path: ../..

--- a/lib/apis/sign_api/models/json_rpc_models.dart
+++ b/lib/apis/sign_api/models/json_rpc_models.dart
@@ -35,7 +35,7 @@ class WcPairingPingRequest {
 class WcSessionProposeRequest {
   final List<Relay> relays;
   final Map<String, RequiredNamespace> requiredNamespaces;
-  final Map<String, RequiredNamespace> optionalNamespaces;
+  final Map<String, RequiredNamespace>? optionalNamespaces;
   final Map<String, String>? sessionProperties;
   final ConnectionMetadata proposer;
 

--- a/lib/apis/sign_api/models/json_rpc_models.g.dart
+++ b/lib/apis/sign_api/models/json_rpc_models.g.dart
@@ -44,7 +44,7 @@ WcSessionProposeRequest _$WcSessionProposeRequestFromJson(
             MapEntry(k, RequiredNamespace.fromJson(e as Map<String, dynamic>)),
       ),
       optionalNamespaces:
-          (json['optionalNamespaces'] as Map<String, dynamic>).map(
+          (json['optionalNamespaces'] as Map<String, dynamic>?)?.map(
         (k, e) =>
             MapEntry(k, RequiredNamespace.fromJson(e as Map<String, dynamic>)),
       ),
@@ -61,7 +61,6 @@ Map<String, dynamic> _$WcSessionProposeRequestToJson(
   final val = <String, dynamic>{
     'relays': instance.relays,
     'requiredNamespaces': instance.requiredNamespaces,
-    'optionalNamespaces': instance.optionalNamespaces,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -70,6 +69,7 @@ Map<String, dynamic> _$WcSessionProposeRequestToJson(
     }
   }
 
+  writeNotNull('optionalNamespaces', instance.optionalNamespaces);
   writeNotNull('sessionProperties', instance.sessionProperties);
   val['proposer'] = instance.proposer;
   return val;

--- a/lib/apis/sign_api/sign_engine.dart
+++ b/lib/apis/sign_api/sign_engine.dart
@@ -159,7 +159,7 @@ class SignEngine implements ISignEngine {
       relays: request.relays,
       proposer: request.proposer,
       requiredNamespaces: request.requiredNamespaces,
-      optionalNamespaces: request.optionalNamespaces,
+      optionalNamespaces: request.optionalNamespaces ?? {},
       sessionProperties: request.sessionProperties,
       pairingTopic: pTopic,
     );
@@ -176,7 +176,7 @@ class SignEngine implements ISignEngine {
         selfPublicKey: publicKey,
         pairingTopic: pTopic,
         requiredNamespaces: request.requiredNamespaces,
-        optionalNamespaces: request.optionalNamespaces,
+        optionalNamespaces: request.optionalNamespaces ?? {},
         sessionProperties: request.sessionProperties,
         completer: completer,
       ),
@@ -786,7 +786,7 @@ class SignEngine implements ISignEngine {
         relays: proposeRequest.relays,
         proposer: proposeRequest.proposer,
         requiredNamespaces: proposeRequest.requiredNamespaces,
-        optionalNamespaces: proposeRequest.optionalNamespaces,
+        optionalNamespaces: proposeRequest.optionalNamespaces ?? {},
         sessionProperties: proposeRequest.sessionProperties,
         pairingTopic: topic,
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   http: ^0.13.5
   cryptography: ^2.0.5
   convert: ^3.0.1
-  json_annotation: ^4.7.0
+  json_annotation: ^4.8.0
   pointycastle: ^3.6.2
   x25519: ^0.1.1
   bs58: ^1.0.2


### PR DESCRIPTION
The Caip-25 says optionalNamespaces cannot be mandated. 
When you run this demo https://react-dapp-v2-with-ethers.vercel.app/ and connect to it with the WalletConnectFlutterV2 an error is thrown since the dapp correctly omits the optionalNamespaces property. 

# Description

- buildrunner requires json_annotation: ^4.8.0 
- WcSessionProposeRequest.optionalNamespaces was made nullable in order for the generated json consumer not to choke on missing optionalNamespaces

Resolves https://github.com/WalletConnect/WalletConnectFlutterV2/issues/21

## How Has This Been Tested?

- flutter analyze
- flutter test (01:16 +181: All tests passed! )

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update