### PR TITLE
Pairing Events, Pairing Throws Errors on Error Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.3
+
+- Fixed a bug with sendError not causing an error to be thrown on the client side
+- Added `onPairingCreate` event. It is emitted when pair and create are called
+- Added `pairing.updateExpiry` time validation.
+
 ## 1.1.2
 
 - Fixed an issue with requests crashing if an error was thrown

--- a/lib/apis/core/pairing/i_pairing.dart
+++ b/lib/apis/core/pairing/i_pairing.dart
@@ -6,6 +6,8 @@ import 'package:walletconnect_flutter_v2/apis/models/json_rpc_error.dart';
 import 'package:walletconnect_flutter_v2/apis/models/json_rpc_request.dart';
 
 abstract class IPairing {
+  abstract final Event<PairingEvent> onPairingCreate;
+  abstract final Event<PairingActivateEvent> onPairingActivate;
   abstract final Event<PairingEvent> onPairingPing;
   abstract final Event<PairingInvalidEvent> onPairingInvalid;
   abstract final Event<PairingEvent> onPairingDelete;

--- a/lib/apis/core/pairing/utils/pairing_models.dart
+++ b/lib/apis/core/pairing/utils/pairing_models.dart
@@ -124,10 +124,12 @@ class Redirect {
 class CreateResponse {
   String topic;
   Uri uri;
+  PairingInfo pairingInfo;
 
   CreateResponse({
     required this.topic,
     required this.uri,
+    required this.pairingInfo,
   });
 
   @override
@@ -189,6 +191,21 @@ class PairingEvent extends EventArgs {
   @override
   String toString() {
     return 'PairingEvent(id: $id, topic: $topic, error: $error)';
+  }
+}
+
+class PairingActivateEvent extends EventArgs {
+  String topic;
+  int expiry;
+
+  PairingActivateEvent({
+    required this.topic,
+    required this.expiry,
+  });
+
+  @override
+  String toString() {
+    return 'PairingActivateEvent(topic: $topic, expiry: $expiry)';
   }
 }
 

--- a/lib/apis/sign_api/i_sign_engine_app.dart
+++ b/lib/apis/sign_api/i_sign_engine_app.dart
@@ -9,7 +9,6 @@ import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_events
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_models.dart';
 
 abstract class ISignEngineApp extends ISignEngineCommon {
-  abstract final Event<SessionConnect> onSessionConnect;
   abstract final Event<SessionUpdate> onSessionUpdate;
   abstract final Event<SessionExtend> onSessionExtend;
   abstract final Event<SessionEvent> onSessionEvent;

--- a/lib/apis/sign_api/i_sign_engine_common.dart
+++ b/lib/apis/sign_api/i_sign_engine_common.dart
@@ -10,6 +10,7 @@ import 'package:walletconnect_flutter_v2/apis/sign_api/models/session_models.dar
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_events.dart';
 
 abstract class ISignEngineCommon {
+  abstract final Event<SessionConnect> onSessionConnect;
   abstract final Event<SessionDelete> onSessionDelete;
   abstract final Event<SessionExpire> onSessionExpire;
   abstract final Event<SessionPing> onSessionPing;

--- a/lib/apis/web3wallet/web3wallet.dart
+++ b/lib/apis/web3wallet/web3wallet.dart
@@ -151,6 +151,8 @@ class Web3Wallet implements IWeb3Wallet {
   ///---------- SIGN ENGINE ----------///
 
   @override
+  Event<SessionConnect> get onSessionConnect => signEngine.onSessionConnect;
+  @override
   Event<SessionDelete> get onSessionDelete => signEngine.onSessionDelete;
   @override
   Event<SessionExpire> get onSessionExpire => signEngine.onSessionExpire;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: walletconnect_flutter_v2
 description: WalletConnect v2 client made in dart for flutter.
-version: 1.1.2
+version: 1.1.3
 repository: https://github.com/WalletConnect/WalletConnectFlutterV2
 
 environment:

--- a/test/core_api/pairing_test.dart
+++ b/test/core_api/pairing_test.dart
@@ -9,6 +9,7 @@ import 'package:walletconnect_flutter_v2/apis/core/relay_client/relay_client_mod
 import 'package:walletconnect_flutter_v2/apis/models/json_rpc_error.dart';
 import 'package:walletconnect_flutter_v2/apis/models/basic_models.dart';
 import 'package:walletconnect_flutter_v2/apis/models/uri_parse_result.dart';
+import 'package:walletconnect_flutter_v2/apis/utils/constants.dart';
 import 'package:walletconnect_flutter_v2/apis/utils/method_constants.dart';
 import 'package:walletconnect_flutter_v2/apis/utils/walletconnect_utils.dart';
 
@@ -106,7 +107,15 @@ void main() {
 
     group('create', () {
       test('returns pairing topic and URI in expected format', () async {
+        Completer completer = Completer();
+        int counter = 0;
+        coreA.pairing.onPairingCreate.subscribe((args) {
+          counter++;
+          completer.complete();
+        });
+
         CreateResponse response = await coreA.pairing.create();
+        await completer.future;
         expect(response.topic.length, 64);
         // print(response.uri);
         // print('${coreA.protocol}:${response.topic}@${coreA.version}');
@@ -116,6 +125,7 @@ void main() {
               ),
           true,
         );
+        expect(counter, 1);
 
         response = await coreB.pairing.create(methods: [
           [MethodConstants.WC_SESSION_PROPOSE],
@@ -137,7 +147,17 @@ void main() {
       test("can pair via provided URI", () async {
         final CreateResponse response = await coreA.pairing.create();
 
+        Completer completer = Completer();
+        int counter = 0;
+        coreB.pairing.onPairingCreate.subscribe((args) {
+          counter++;
+          completer.complete();
+        });
+
         await coreB.pairing.pair(uri: response.uri);
+        await completer.future;
+
+        expect(counter, 1);
 
         expect(coreA.pairing.getPairings().length, 1);
         expect(coreB.pairing.getPairings().length, 1);
@@ -178,8 +198,31 @@ void main() {
       final CreateResponse response = await coreA.pairing.create();
       final int mockExpiry = 1111111;
 
-      coreA.pairing.updateExpiry(topic: response.topic, expiry: mockExpiry);
+      await coreA.pairing
+          .updateExpiry(topic: response.topic, expiry: mockExpiry);
       expect(coreA.pairing.getStore().get(response.topic)!.expiry, mockExpiry);
+      expect(coreA.expirer.get(response.topic), mockExpiry);
+    });
+
+    test('update expiry throws error if expiry past 30 days', () async {
+      final CreateResponse response = await coreA.pairing.create();
+      final int mockExpiry = WalletConnectUtils.calculateExpiry(
+        WalletConnectConstants.THIRTY_DAYS + 1,
+      );
+
+      expect(
+        () async => await coreA.pairing.updateExpiry(
+          topic: response.topic,
+          expiry: mockExpiry,
+        ),
+        throwsA(
+          isA<WalletConnectError>().having(
+            (e) => e.message,
+            'message',
+            'Expiry cannot be more than 30 days away',
+          ),
+        ),
+      );
     });
 
     test("can update peer metadata", () async {
@@ -396,7 +439,7 @@ void main() {
             () async => await coreA.pairing.ping(topic: 'abc'),
             throwsA(
               predicate((e) =>
-                  e is JsonRpcError &&
+                  e is WalletConnectError &&
                   e.message ==
                       "No matching key. pairing topic doesn't exist: abc"),
             ),
@@ -410,7 +453,7 @@ void main() {
             () async => await coreA.pairing.disconnect(topic: 'abc'),
             throwsA(
               predicate((e) =>
-                  e is JsonRpcError &&
+                  e is WalletConnectError &&
                   e.message ==
                       "No matching key. pairing topic doesn't exist: abc"),
             ),

--- a/test/sign_api/sign_client_test.dart
+++ b/test/sign_api/sign_client_test.dart
@@ -584,7 +584,7 @@ void signingEngineTests({
         );
       });
 
-      test('received correctly', () async {
+      test('throws catchable error properly', () async {
         await SignClientHelpers.testConnectPairReject(
           clientA,
           clientB,

--- a/test/sign_api/sign_client_test.dart
+++ b/test/sign_api/sign_client_test.dart
@@ -235,698 +235,705 @@ void signingEngineTests({
       await clientB.core.relayClient.disconnect();
     });
 
-    // group('happy path', () {
-    //   test('Initializes', () async {
-    //     expect(clientA.core.pairing.getPairings().length, 0);
-    //     expect(clientB.core.pairing.getPairings().length, 0);
-    //   });
+    group('happy path', () {
+      test('Initializes', () async {
+        expect(clientA.core.pairing.getPairings().length, 0);
+        expect(clientB.core.pairing.getPairings().length, 0);
+      });
 
-    //   test('connects, reconnects, and emits proper events', () async {
-    //     Completer completerA = Completer();
-    //     Completer completerB = Completer();
-    //     int counterA = 0;
-    //     int counterB = 0;
-    //     clientA.onSessionConnect.subscribe((args) {
-    //       counterA++;
-    //       completerA.complete();
-    //     });
-    //     clientB.onSessionProposal.subscribe((args) {
-    //       counterB++;
-    //       completerB.complete();
-    //     });
+      test('connects, reconnects, and emits proper events', () async {
+        Completer completerA = Completer();
+        Completer completerB = Completer();
+        int counterA = 0;
+        int counterB = 0;
+        clientA.onSessionConnect.subscribe((args) {
+          counterA++;
+          completerA.complete();
+        });
+        clientB.onSessionProposal.subscribe((args) {
+          counterB++;
+          completerB.complete();
+        });
 
-    //     final connectionInfo = await SignClientHelpers.testConnectPairApprove(
-    //       clientA,
-    //       clientB,
-    //     );
+        final connectionInfo = await SignClientHelpers.testConnectPairApprove(
+          clientA,
+          clientB,
+        );
 
-    //     // await Future.delayed(Duration(milliseconds: 100));
-    //     await completerA.future;
-    //     await completerB.future;
+        // await Future.delayed(Duration(milliseconds: 100));
+        await completerA.future;
+        await completerB.future;
 
-    //     completerA = Completer();
-    //     completerB = Completer();
-    //     // clientA.onSessionConnect.unsubscribeAll();
-    //     // clientB.onSessionProposal.unsubscribeAll();
-    //     // clientA.onSessionConnect.subscribe((args) {
-    //     //   counterA++;
-    //     //   completerA.complete();
-    //     // });
-    //     // clientB.onSessionProposal.subscribe((args) {
-    //     //   counterB++;
-    //     //   completerB.complete();
-    //     // });
+        completerA = Completer();
+        completerB = Completer();
+        // clientA.onSessionConnect.unsubscribeAll();
+        // clientB.onSessionProposal.unsubscribeAll();
+        // clientA.onSessionConnect.subscribe((args) {
+        //   counterA++;
+        //   completerA.complete();
+        // });
+        // clientB.onSessionProposal.subscribe((args) {
+        //   counterB++;
+        //   completerB.complete();
+        // });
 
-    //     expect(counterA, 1);
-    //     expect(counterB, 1);
+        expect(counterA, 1);
+        expect(counterB, 1);
 
-    //     expect(
-    //       clientA.pairings.getAll().length,
-    //       clientB.pairings.getAll().length,
-    //     );
-    //     expect(clientA.getActiveSessions().length, 1);
-    //     expect(clientB.getActiveSessions().length, 1);
-    //     expect(
-    //       clientA
-    //           .getSessionsForPairing(
-    //             pairingTopic: connectionInfo.pairing.topic,
-    //           )
-    //           .length,
-    //       1,
-    //     );
-    //     expect(
-    //       clientB
-    //           .getSessionsForPairing(
-    //             pairingTopic: connectionInfo.pairing.topic,
-    //           )
-    //           .length,
-    //       1,
-    //     );
-    //     final _ = await SignClientHelpers.testConnectPairApprove(
-    //       clientA,
-    //       clientB,
-    //       pairingTopic: connectionInfo.pairing.topic,
-    //     );
+        expect(
+          clientA.pairings.getAll().length,
+          clientB.pairings.getAll().length,
+        );
+        expect(clientA.getActiveSessions().length, 1);
+        expect(clientB.getActiveSessions().length, 1);
+        expect(
+          clientA
+              .getSessionsForPairing(
+                pairingTopic: connectionInfo.pairing.topic,
+              )
+              .length,
+          1,
+        );
+        expect(
+          clientB
+              .getSessionsForPairing(
+                pairingTopic: connectionInfo.pairing.topic,
+              )
+              .length,
+          1,
+        );
+        final _ = await SignClientHelpers.testConnectPairApprove(
+          clientA,
+          clientB,
+          pairingTopic: connectionInfo.pairing.topic,
+        );
 
-    //     // await Future.delayed(Duration(milliseconds: 100));
-    //     await completerA.future;
-    //     await completerB.future;
+        // await Future.delayed(Duration(milliseconds: 100));
+        await completerA.future;
+        await completerB.future;
 
-    //     expect(counterA, 2);
-    //     expect(counterB, 2);
+        expect(counterA, 2);
+        expect(counterB, 2);
 
-    //     clientA.onSessionConnect.unsubscribeAll();
-    //     clientB.onSessionProposal.unsubscribeAll();
-    //   });
+        clientA.onSessionConnect.unsubscribeAll();
+        clientB.onSessionProposal.unsubscribeAll();
+      });
 
-    //   test('connects, and reconnects with scan latency', () async {
-    //     final connectionInfo = await SignClientHelpers.testConnectPairApprove(
-    //       clientA,
-    //       clientB,
-    //       qrCodeScanLatencyMs: 1000,
-    //     );
-    //     expect(
-    //       clientA.pairings.getAll().length,
-    //       clientB.pairings.getAll().length,
-    //     );
-    //     final _ = await SignClientHelpers.testConnectPairApprove(
-    //       clientA,
-    //       clientB,
-    //       pairingTopic: connectionInfo.pairing.topic,
-    //       qrCodeScanLatencyMs: 1000,
-    //     );
-    //   });
-    // });
+      test('connects, and reconnects with scan latency', () async {
+        final connectionInfo = await SignClientHelpers.testConnectPairApprove(
+          clientA,
+          clientB,
+          qrCodeScanLatencyMs: 1000,
+        );
+        expect(
+          clientA.pairings.getAll().length,
+          clientB.pairings.getAll().length,
+        );
+        final _ = await SignClientHelpers.testConnectPairApprove(
+          clientA,
+          clientB,
+          pairingTopic: connectionInfo.pairing.topic,
+          qrCodeScanLatencyMs: 1000,
+        );
+      });
+    });
 
-    // group('connect', () {
-    //   test('creates correct URI', () async {
-    //     ConnectResponse response = await clientA.connect(
-    //       requiredNamespaces: TEST_REQUIRED_NAMESPACES,
-    //     );
+    group('connect', () {
+      test('creates correct URI', () async {
+        ConnectResponse response = await clientA.connect(
+          requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+        );
 
-    //     expect(response.uri != null, true);
-    //     URIParseResult parsed = WalletConnectUtils.parseUri(response.uri!);
-    //     expect(parsed.protocol, 'wc');
-    //     expect(parsed.version, '2');
-    //     expect(parsed.topic, response.pairingTopic);
-    //     expect(parsed.relay.protocol, 'irn');
-    //     if (clientA is IWeb3App) {
-    //       expect(parsed.methods.length, 3);
-    //       expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
-    //       expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
-    //       expect(parsed.methods[2], MethodConstants.WC_AUTH_REQUEST);
-    //     } else {
-    //       expect(parsed.methods.length, 2);
-    //       expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
-    //       expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
-    //     }
+        expect(response.uri != null, true);
+        URIParseResult parsed = WalletConnectUtils.parseUri(response.uri!);
+        expect(parsed.protocol, 'wc');
+        expect(parsed.version, '2');
+        expect(parsed.topic, response.pairingTopic);
+        expect(parsed.relay.protocol, 'irn');
+        if (clientA is IWeb3App) {
+          expect(parsed.methods.length, 3);
+          expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+          expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
+          expect(parsed.methods[2], MethodConstants.WC_AUTH_REQUEST);
+        } else {
+          expect(parsed.methods.length, 2);
+          expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+          expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
+        }
 
-    //     response = await clientA.connect(
-    //       requiredNamespaces: TEST_REQUIRED_NAMESPACES,
-    //       methods: [],
-    //     );
+        response = await clientA.connect(
+          requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+          methods: [],
+        );
 
-    //     expect(response.uri != null, true);
-    //     parsed = WalletConnectUtils.parseUri(response.uri!);
-    //     expect(parsed.protocol, 'wc');
-    //     expect(parsed.version, '2');
-    //     expect(parsed.relay.protocol, 'irn');
-    //     expect(parsed.methods.length, 0);
-    //   });
+        expect(response.uri != null, true);
+        parsed = WalletConnectUtils.parseUri(response.uri!);
+        expect(parsed.protocol, 'wc');
+        expect(parsed.version, '2');
+        expect(parsed.relay.protocol, 'irn');
+        expect(parsed.methods.length, 0);
+      });
 
-    //   test('invalid topic', () {
-    //     expect(
-    //       () async => await clientA.connect(
-    //         requiredNamespaces: TEST_REQUIRED_NAMESPACES,
-    //         pairingTopic: TEST_TOPIC_INVALID,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'No matching key. pairing topic doesn\'t exist: abc',
-    //         ),
-    //       ),
-    //     );
-    //   });
+      test('invalid topic', () {
+        expect(
+          () async => await clientA.connect(
+            requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+            pairingTopic: TEST_TOPIC_INVALID,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'No matching key. pairing topic doesn\'t exist: abc',
+            ),
+          ),
+        );
+      });
 
-    //   test('invalid required and optional namespaces', () {
-    //     expect(
-    //       () async => await clientA.connect(
-    //         requiredNamespaces: TEST_REQUIRED_NAMESPACES_INVALID_CHAINS_1,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Unsupported chains. connect() check requiredNamespaces. requiredNamespace, namespace is a chainId, but chains is not empty',
-    //         ),
-    //       ),
-    //     );
-    //     expect(
-    //       () async => await clientA.connect(
-    //         requiredNamespaces: TEST_REQUIRED_NAMESPACES,
-    //         optionalNamespaces: TEST_REQUIRED_NAMESPACES_INVALID_CHAINS_1,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Unsupported chains. connect() check optionalNamespaces. requiredNamespace, namespace is a chainId, but chains is not empty',
-    //         ),
-    //       ),
-    //     );
-    //   });
-    // });
+      test('invalid required and optional namespaces', () {
+        expect(
+          () async => await clientA.connect(
+            requiredNamespaces: TEST_REQUIRED_NAMESPACES_INVALID_CHAINS_1,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Unsupported chains. connect() check requiredNamespaces. requiredNamespace, namespace is a chainId, but chains is not empty',
+            ),
+          ),
+        );
+        expect(
+          () async => await clientA.connect(
+            requiredNamespaces: TEST_REQUIRED_NAMESPACES,
+            optionalNamespaces: TEST_REQUIRED_NAMESPACES_INVALID_CHAINS_1,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Unsupported chains. connect() check optionalNamespaces. requiredNamespace, namespace is a chainId, but chains is not empty',
+            ),
+          ),
+        );
+      });
+    });
 
-    // group('pair', () {
-    //   test('throws with invalid methods', () {
-    //     final String uriWithMethods = '$TEST_URI&methods=[wc_swag]';
+    group('pair', () {
+      test('throws with invalid methods', () {
+        final String uriWithMethods = '$TEST_URI&methods=[wc_swag]';
 
-    //     expect(
-    //       () async => await clientB.pair(uri: Uri.parse(uriWithMethods)),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Unsupported wc_ method. The following methods are not registered: wc_swag.',
-    //         ),
-    //       ),
-    //     );
-    //   });
-    // });
+        expect(
+          () async => await clientB.pair(uri: Uri.parse(uriWithMethods)),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Unsupported wc_ method. The following methods are not registered: wc_swag.',
+            ),
+          ),
+        );
+      });
+    });
 
-    // group('approveSession', () {
-    //   setUp(() async {
-    //     await clientB.proposals.set(
-    //       TEST_PROPOSAL_VALID_ID.toString(),
-    //       TEST_PROPOSAL_VALID,
-    //     );
-    //     await clientB.proposals.set(
-    //       TEST_PROPOSAL_EXPIRED_ID.toString(),
-    //       TEST_PROPOSAL_EXPIRED,
-    //     );
-    //     await clientB.core.expirer.set(
-    //       TEST_PROPOSAL_EXPIRED_ID.toString(),
-    //       TEST_PROPOSAL_EXPIRED.expiry,
-    //     );
-    //     await clientB.proposals.set(
-    //       TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES_ID.toString(),
-    //       TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES,
-    //     );
-    //     await clientB.proposals.set(
-    //       TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES_ID.toString(),
-    //       TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES,
-    //     );
-    //   });
+    group('approveSession', () {
+      setUp(() async {
+        await clientB.proposals.set(
+          TEST_PROPOSAL_VALID_ID.toString(),
+          TEST_PROPOSAL_VALID,
+        );
+        await clientB.proposals.set(
+          TEST_PROPOSAL_EXPIRED_ID.toString(),
+          TEST_PROPOSAL_EXPIRED,
+        );
+        await clientB.core.expirer.set(
+          TEST_PROPOSAL_EXPIRED_ID.toString(),
+          TEST_PROPOSAL_EXPIRED.expiry,
+        );
+        await clientB.proposals.set(
+          TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES_ID.toString(),
+          TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES,
+        );
+        await clientB.proposals.set(
+          TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES_ID.toString(),
+          TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES,
+        );
+      });
 
-    //   test('invalid proposal id', () async {
-    //     expect(
-    //       () async => await clientB.approveSession(
-    //         id: TEST_APPROVE_ID_INVALID,
-    //         namespaces: TEST_NAMESPACES,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'No matching key. proposal id doesn\'t exist: $TEST_APPROVE_ID_INVALID',
-    //         ),
-    //       ),
-    //     );
+      test('invalid proposal id', () async {
+        expect(
+          () async => await clientB.approveSession(
+            id: TEST_APPROVE_ID_INVALID,
+            namespaces: TEST_NAMESPACES,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'No matching key. proposal id doesn\'t exist: $TEST_APPROVE_ID_INVALID',
+            ),
+          ),
+        );
 
-    //     int counter = 0;
-    //     Completer completer = Completer();
-    //     clientB.core.expirer.onExpire.subscribe((args) {
-    //       counter++;
-    //       completer.complete();
-    //     });
-    //     int counterSession = 0;
-    //     Completer completer2 = Completer();
-    //     clientB.onProposalExpire.subscribe((args) {
-    //       counterSession++;
-    //       completer2.complete();
-    //     });
-    //     expect(
-    //       () async => await clientB.approveSession(
-    //         id: TEST_PROPOSAL_EXPIRED_ID,
-    //         namespaces: TEST_NAMESPACES,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Expired. proposal id: $TEST_PROPOSAL_EXPIRED_ID',
-    //         ),
-    //       ),
-    //     );
+        int counter = 0;
+        Completer completer = Completer();
+        clientB.core.expirer.onExpire.subscribe((args) {
+          counter++;
+          completer.complete();
+        });
+        int counterSession = 0;
+        Completer completer2 = Completer();
+        clientB.onProposalExpire.subscribe((args) {
+          counterSession++;
+          completer2.complete();
+        });
+        expect(
+          () async => await clientB.approveSession(
+            id: TEST_PROPOSAL_EXPIRED_ID,
+            namespaces: TEST_NAMESPACES,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Expired. proposal id: $TEST_PROPOSAL_EXPIRED_ID',
+            ),
+          ),
+        );
 
-    //     // await Future.delayed(Duration(milliseconds: 250));
-    //     await completer.future;
-    //     await completer2.future;
+        // await Future.delayed(Duration(milliseconds: 250));
+        await completer.future;
+        await completer2.future;
 
-    //     expect(
-    //       clientB.proposals.has(
-    //         TEST_PROPOSAL_EXPIRED_ID.toString(),
-    //       ),
-    //       false,
-    //     );
-    //     expect(counter, 1);
-    //     expect(counterSession, 1);
-    //     clientB.core.expirer.onExpire.unsubscribeAll();
-    //     clientB.onProposalExpire.unsubscribeAll();
-    //   });
+        expect(
+          clientB.proposals.has(
+            TEST_PROPOSAL_EXPIRED_ID.toString(),
+          ),
+          false,
+        );
+        expect(counter, 1);
+        expect(counterSession, 1);
+        clientB.core.expirer.onExpire.unsubscribeAll();
+        clientB.onProposalExpire.unsubscribeAll();
+      });
 
-    //   test('invalid namespaces', () async {
-    //     expect(
-    //       () async => await clientB.approveSession(
-    //         id: TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES_ID,
-    //         namespaces: TEST_NAMESPACES,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Unsupported chains. approve() check requiredNamespaces. requiredNamespace, namespace is a chainId, but chains is not empty',
-    //         ),
-    //       ),
-    //     );
-    //     expect(
-    //       () async => await clientB.approveSession(
-    //         id: TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES_ID,
-    //         namespaces: TEST_NAMESPACES,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Unsupported chains. approve() check optionalNamespaces. requiredNamespace, namespace is a chainId, but chains is not empty',
-    //         ),
-    //       ),
-    //     );
-    //     expect(
-    //       () async => await clientB.approveSession(
-    //         id: TEST_PROPOSAL_VALID_ID,
-    //         namespaces: TEST_NAMESPACES_NONCONFORMING_KEY_1,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Non conforming namespaces. approve() namespaces keys don\'t satisfy requiredNamespaces',
-    //         ),
-    //       ),
-    //     );
-    //   });
-    // });
+      test('invalid namespaces', () async {
+        expect(
+          () async => await clientB.approveSession(
+            id: TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES_ID,
+            namespaces: TEST_NAMESPACES,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Unsupported chains. approve() check requiredNamespaces. requiredNamespace, namespace is a chainId, but chains is not empty',
+            ),
+          ),
+        );
+        expect(
+          () async => await clientB.approveSession(
+            id: TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES_ID,
+            namespaces: TEST_NAMESPACES,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Unsupported chains. approve() check optionalNamespaces. requiredNamespace, namespace is a chainId, but chains is not empty',
+            ),
+          ),
+        );
+        expect(
+          () async => await clientB.approveSession(
+            id: TEST_PROPOSAL_VALID_ID,
+            namespaces: TEST_NAMESPACES_NONCONFORMING_KEY_1,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Non conforming namespaces. approve() namespaces keys don\'t satisfy requiredNamespaces',
+            ),
+          ),
+        );
+      });
+    });
 
-    // group('rejectSession', () {
-    //   setUp(() async {
-    //     await clientB.proposals.set(
-    //       TEST_PROPOSAL_VALID_ID.toString(),
-    //       TEST_PROPOSAL_VALID,
-    //     );
-    //     await clientB.proposals.set(
-    //       TEST_PROPOSAL_EXPIRED_ID.toString(),
-    //       TEST_PROPOSAL_EXPIRED,
-    //     );
-    //     await clientB.core.expirer.set(
-    //       TEST_PROPOSAL_EXPIRED_ID.toString(),
-    //       TEST_PROPOSAL_EXPIRED.expiry,
-    //     );
-    //     await clientB.proposals.set(
-    //       TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES_ID.toString(),
-    //       TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES,
-    //     );
-    //     await clientB.proposals.set(
-    //       TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES_ID.toString(),
-    //       TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES,
-    //     );
-    //   });
+    group('rejectSession', () {
+      setUp(() async {
+        await clientB.proposals.set(
+          TEST_PROPOSAL_VALID_ID.toString(),
+          TEST_PROPOSAL_VALID,
+        );
+        await clientB.proposals.set(
+          TEST_PROPOSAL_EXPIRED_ID.toString(),
+          TEST_PROPOSAL_EXPIRED,
+        );
+        await clientB.core.expirer.set(
+          TEST_PROPOSAL_EXPIRED_ID.toString(),
+          TEST_PROPOSAL_EXPIRED.expiry,
+        );
+        await clientB.proposals.set(
+          TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES_ID.toString(),
+          TEST_PROPOSAL_INVALID_REQUIRED_NAMESPACES,
+        );
+        await clientB.proposals.set(
+          TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES_ID.toString(),
+          TEST_PROPOSAL_INVALID_OPTIONAL_NAMESPACES,
+        );
+      });
 
-    //   test('deletes the proposal', () async {
-    //     await clientB.rejectSession(
-    //       id: TEST_PROPOSAL_VALID_ID,
-    //       reason: WalletConnectError(code: -1, message: 'reason'),
-    //     );
+      test('received correctly', () async {
+        await SignClientHelpers.testConnectPairReject(
+          clientA,
+          clientB,
+        );
+      });
 
-    //     expect(
-    //       clientB.proposals.has(
-    //         TEST_PROPOSAL_VALID_ID.toString(),
-    //       ),
-    //       false,
-    //     );
-    //   });
+      test('deletes the proposal', () async {
+        await clientB.rejectSession(
+          id: TEST_PROPOSAL_VALID_ID,
+          reason: WalletConnectError(code: -1, message: 'reason'),
+        );
 
-    //   test('invalid proposal id', () async {
-    //     expect(
-    //       () async => await clientB.rejectSession(
-    //         id: TEST_APPROVE_ID_INVALID,
-    //         reason: WalletConnectError(code: -1, message: 'reason'),
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'No matching key. proposal id doesn\'t exist: $TEST_APPROVE_ID_INVALID',
-    //         ),
-    //       ),
-    //     );
+        expect(
+          clientB.proposals.has(
+            TEST_PROPOSAL_VALID_ID.toString(),
+          ),
+          false,
+        );
+      });
 
-    //     int counter = 0;
-    //     Completer completer = Completer();
-    //     clientB.core.expirer.onExpire.subscribe((args) {
-    //       counter++;
-    //       completer.complete();
-    //     });
-    //     int counter2 = 0;
-    //     Completer completer2 = Completer();
-    //     clientB.onProposalExpire.subscribe((args) {
-    //       counter2++;
-    //       completer2.complete();
-    //     });
-    //     expect(
-    //       () async => await clientB.rejectSession(
-    //         id: TEST_PROPOSAL_EXPIRED_ID,
-    //         reason: WalletConnectError(code: -1, message: 'reason'),
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Expired. proposal id: $TEST_PROPOSAL_EXPIRED_ID',
-    //         ),
-    //       ),
-    //     );
+      test('invalid proposal id', () async {
+        expect(
+          () async => await clientB.rejectSession(
+            id: TEST_APPROVE_ID_INVALID,
+            reason: WalletConnectError(code: -1, message: 'reason'),
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'No matching key. proposal id doesn\'t exist: $TEST_APPROVE_ID_INVALID',
+            ),
+          ),
+        );
 
-    //     // await Future.delayed(Duration(milliseconds: 150));
-    //     await completer.future;
-    //     await completer2.future;
+        int counter = 0;
+        Completer completer = Completer();
+        clientB.core.expirer.onExpire.subscribe((args) {
+          counter++;
+          completer.complete();
+        });
+        int counter2 = 0;
+        Completer completer2 = Completer();
+        clientB.onProposalExpire.subscribe((args) {
+          counter2++;
+          completer2.complete();
+        });
+        expect(
+          () async => await clientB.rejectSession(
+            id: TEST_PROPOSAL_EXPIRED_ID,
+            reason: WalletConnectError(code: -1, message: 'reason'),
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Expired. proposal id: $TEST_PROPOSAL_EXPIRED_ID',
+            ),
+          ),
+        );
 
-    //     expect(
-    //       clientB.proposals.has(
-    //         TEST_PROPOSAL_EXPIRED_ID.toString(),
-    //       ),
-    //       false,
-    //     );
-    //     expect(counter, 1);
-    //     expect(counter2, 1);
-    //     clientB.core.expirer.onExpire.unsubscribeAll();
-    //     clientB.onProposalExpire.unsubscribeAll();
-    //   });
-    // });
+        // await Future.delayed(Duration(milliseconds: 150));
+        await completer.future;
+        await completer2.future;
 
-    // group('updateSession', () {
-    //   test('works', () async {
-    //     final connectionInfo = await SignClientHelpers.testConnectPairApprove(
-    //       clientA,
-    //       clientB,
-    //       requiredNamespaces: {
-    //         EVM_NAMESPACE: TEST_ETH_ARB_REQUIRED_NAMESPACE,
-    //       },
-    //     );
+        expect(
+          clientB.proposals.has(
+            TEST_PROPOSAL_EXPIRED_ID.toString(),
+          ),
+          false,
+        );
+        expect(counter, 1);
+        expect(counter2, 1);
+        clientB.core.expirer.onExpire.unsubscribeAll();
+        clientB.onProposalExpire.unsubscribeAll();
+      });
+    });
 
-    //     int counter = 0;
-    //     Completer completer = Completer();
-    //     clientA.onSessionUpdate.subscribe((args) {
-    //       counter++;
-    //       completer.complete();
-    //     });
+    group('updateSession', () {
+      test('works', () async {
+        final connectionInfo = await SignClientHelpers.testConnectPairApprove(
+          clientA,
+          clientB,
+          requiredNamespaces: {
+            EVM_NAMESPACE: TEST_ETH_ARB_REQUIRED_NAMESPACE,
+          },
+        );
 
-    //     await clientB.updateSession(
-    //       topic: connectionInfo.session.topic,
-    //       namespaces: {EVM_NAMESPACE: TEST_ETH_ARB_NAMESPACE},
-    //     );
+        int counter = 0;
+        Completer completer = Completer();
+        clientA.onSessionUpdate.subscribe((args) {
+          counter++;
+          completer.complete();
+        });
 
-    //     // await Future.delayed(Duration(milliseconds: 100));
-    //     await completer.future;
+        await clientB.updateSession(
+          topic: connectionInfo.session.topic,
+          namespaces: {EVM_NAMESPACE: TEST_ETH_ARB_NAMESPACE},
+        );
 
-    //     final resultA =
-    //         clientA.sessions.get(connectionInfo.session.topic)!.namespaces;
-    //     final resultB =
-    //         clientB.sessions.get(connectionInfo.session.topic)!.namespaces;
-    //     expect(resultA, equals({EVM_NAMESPACE: TEST_ETH_ARB_NAMESPACE}));
-    //     expect(resultB, equals({EVM_NAMESPACE: TEST_ETH_ARB_NAMESPACE}));
-    //     expect(counter, 1);
+        // await Future.delayed(Duration(milliseconds: 100));
+        await completer.future;
 
-    //     clientA.onSessionUpdate.unsubscribeAll();
-    //   });
+        final resultA =
+            clientA.sessions.get(connectionInfo.session.topic)!.namespaces;
+        final resultB =
+            clientB.sessions.get(connectionInfo.session.topic)!.namespaces;
+        expect(resultA, equals({EVM_NAMESPACE: TEST_ETH_ARB_NAMESPACE}));
+        expect(resultB, equals({EVM_NAMESPACE: TEST_ETH_ARB_NAMESPACE}));
+        expect(counter, 1);
 
-    //   setUp(() async {
-    //     await clientB.sessions.set(
-    //       TEST_SESSION_VALID_TOPIC,
-    //       testSessionValid,
-    //     );
-    //     await clientB.sessions.set(
-    //       TEST_SESSION_EXPIRED_TOPIC,
-    //       testSessionExpired,
-    //     );
-    //     await clientB.core.expirer.set(
-    //       TEST_SESSION_EXPIRED_TOPIC.toString(),
-    //       testSessionExpired.expiry,
-    //     );
-    //   });
+        clientA.onSessionUpdate.unsubscribeAll();
+      });
 
-    //   test('invalid session topic', () async {
-    //     expect(
-    //       () async => await clientB.updateSession(
-    //         topic: TEST_SESSION_INVALID_TOPIC,
-    //         namespaces: TEST_NAMESPACES,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'No matching key. session topic doesn\'t exist: $TEST_SESSION_INVALID_TOPIC',
-    //         ),
-    //       ),
-    //     );
+      setUp(() async {
+        await clientB.sessions.set(
+          TEST_SESSION_VALID_TOPIC,
+          testSessionValid,
+        );
+        await clientB.sessions.set(
+          TEST_SESSION_EXPIRED_TOPIC,
+          testSessionExpired,
+        );
+        await clientB.core.expirer.set(
+          TEST_SESSION_EXPIRED_TOPIC.toString(),
+          testSessionExpired.expiry,
+        );
+      });
 
-    //     int counterExpire = 0;
-    //     Completer completerExpire = Completer();
-    //     clientB.core.expirer.onExpire.subscribe((args) {
-    //       counterExpire++;
-    //       completerExpire.complete();
-    //     });
-    //     int counterSession = 0;
-    //     Completer completerSession = Completer();
-    //     clientB.onSessionExpire.subscribe((args) {
-    //       counterSession++;
-    //       completerSession.complete();
-    //     });
-    //     expect(
-    //       () async => await clientB.updateSession(
-    //         topic: TEST_SESSION_EXPIRED_TOPIC,
-    //         namespaces: TEST_NAMESPACES,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Expired. session topic: $TEST_SESSION_EXPIRED_TOPIC',
-    //         ),
-    //       ),
-    //     );
-    //     // await Future.delayed(Duration(milliseconds: 150));
-    //     await completerExpire.future;
-    //     await completerSession.future;
+      test('invalid session topic', () async {
+        expect(
+          () async => await clientB.updateSession(
+            topic: TEST_SESSION_INVALID_TOPIC,
+            namespaces: TEST_NAMESPACES,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'No matching key. session topic doesn\'t exist: $TEST_SESSION_INVALID_TOPIC',
+            ),
+          ),
+        );
 
-    //     expect(
-    //       clientB.sessions.has(
-    //         TEST_SESSION_EXPIRED_TOPIC,
-    //       ),
-    //       false,
-    //     );
-    //     expect(counterExpire, 1);
-    //     expect(counterSession, 1);
-    //     clientB.core.expirer.onExpire.unsubscribeAll();
-    //     clientB.onSessionExpire.unsubscribeAll();
-    //   });
+        int counterExpire = 0;
+        Completer completerExpire = Completer();
+        clientB.core.expirer.onExpire.subscribe((args) {
+          counterExpire++;
+          completerExpire.complete();
+        });
+        int counterSession = 0;
+        Completer completerSession = Completer();
+        clientB.onSessionExpire.subscribe((args) {
+          counterSession++;
+          completerSession.complete();
+        });
+        expect(
+          () async => await clientB.updateSession(
+            topic: TEST_SESSION_EXPIRED_TOPIC,
+            namespaces: TEST_NAMESPACES,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Expired. session topic: $TEST_SESSION_EXPIRED_TOPIC',
+            ),
+          ),
+        );
+        // await Future.delayed(Duration(milliseconds: 150));
+        await completerExpire.future;
+        await completerSession.future;
 
-    //   test('invalid namespaces', () async {
-    //     expect(
-    //       () async => await clientB.updateSession(
-    //         topic: TEST_SESSION_VALID_TOPIC,
-    //         namespaces: TEST_NAMESPACES_INVALID_ACCOUNTS,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Unsupported accounts. update() namespace, account swag should conform to "namespace:chainId:address" format',
-    //         ),
-    //       ),
-    //     );
-    //     expect(
-    //       () async => await clientB.updateSession(
-    //         topic: TEST_SESSION_VALID_TOPIC,
-    //         namespaces: TEST_NAMESPACES_NONCONFORMING_CHAINS,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Non conforming namespaces. update() namespaces accounts don\'t satisfy requiredNamespaces chains for eip155',
-    //         ),
-    //       ),
-    //     );
-    //   });
-    // });
+        expect(
+          clientB.sessions.has(
+            TEST_SESSION_EXPIRED_TOPIC,
+          ),
+          false,
+        );
+        expect(counterExpire, 1);
+        expect(counterSession, 1);
+        clientB.core.expirer.onExpire.unsubscribeAll();
+        clientB.onSessionExpire.unsubscribeAll();
+      });
 
-    // group('extendSession', () {
-    //   test('works', () async {
-    //     final connectionInfo = await SignClientHelpers.testConnectPairApprove(
-    //       clientA,
-    //       clientB,
-    //     );
+      test('invalid namespaces', () async {
+        expect(
+          () async => await clientB.updateSession(
+            topic: TEST_SESSION_VALID_TOPIC,
+            namespaces: TEST_NAMESPACES_INVALID_ACCOUNTS,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Unsupported accounts. update() namespace, account swag should conform to "namespace:chainId:address" format',
+            ),
+          ),
+        );
+        expect(
+          () async => await clientB.updateSession(
+            topic: TEST_SESSION_VALID_TOPIC,
+            namespaces: TEST_NAMESPACES_NONCONFORMING_CHAINS,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Non conforming namespaces. update() namespaces accounts don\'t satisfy requiredNamespaces chains for eip155',
+            ),
+          ),
+        );
+      });
+    });
 
-    //     final startingExpiryA =
-    //         clientA.sessions.get(connectionInfo.session.topic)!.expiry;
-    //     final startingExpiryB =
-    //         clientB.sessions.get(connectionInfo.session.topic)!.expiry;
-    //     // TODO: Figure out why the expirer and session expiry are not the same
-    //     // expect(
-    //     //   clientA.core.expirer.get(connectionInfo.session.topic) ==
-    //     //       startingExpiryA,
-    //     //   true,
-    //     // );
-    //     // expect(
-    //     //   clientB.core.expirer.get(connectionInfo.session.topic) ==
-    //     //       startingExpiryB,
-    //     //   true,
-    //     // );
+    group('extendSession', () {
+      test('works', () async {
+        final connectionInfo = await SignClientHelpers.testConnectPairApprove(
+          clientA,
+          clientB,
+        );
 
-    //     int counter = 0;
-    //     Completer completer = Completer();
-    //     clientA.onSessionExtend.subscribe((args) {
-    //       counter++;
-    //       completer.complete();
-    //     });
+        final startingExpiryA =
+            clientA.sessions.get(connectionInfo.session.topic)!.expiry;
+        final startingExpiryB =
+            clientB.sessions.get(connectionInfo.session.topic)!.expiry;
+        // TODO: Figure out why the expirer and session expiry are not the same
+        // expect(
+        //   clientA.core.expirer.get(connectionInfo.session.topic) ==
+        //       startingExpiryA,
+        //   true,
+        // );
+        // expect(
+        //   clientB.core.expirer.get(connectionInfo.session.topic) ==
+        //       startingExpiryB,
+        //   true,
+        // );
 
-    //     final offset = 100;
-    //     await Future.delayed(Duration(milliseconds: offset));
+        int counter = 0;
+        Completer completer = Completer();
+        clientA.onSessionExtend.subscribe((args) {
+          counter++;
+          completer.complete();
+        });
 
-    //     await clientB.extendSession(
-    //       topic: connectionInfo.session.topic,
-    //     );
+        final offset = 100;
+        await Future.delayed(Duration(milliseconds: offset));
 
-    //     // await Future.delayed(Duration(milliseconds: 100));
-    //     await completer.future;
+        await clientB.extendSession(
+          topic: connectionInfo.session.topic,
+        );
 
-    //     final endingExpiryA =
-    //         clientA.sessions.get(connectionInfo.session.topic)!.expiry;
-    //     final endingExpiryB =
-    //         clientB.sessions.get(connectionInfo.session.topic)!.expiry;
+        // await Future.delayed(Duration(milliseconds: 100));
+        await completer.future;
 
-    //     expect(
-    //       endingExpiryA >= startingExpiryA,
-    //       true,
-    //     );
-    //     expect(
-    //       endingExpiryB >= startingExpiryB,
-    //       true,
-    //     );
-    //     expect(
-    //       clientA.core.expirer.get(connectionInfo.session.topic) ==
-    //           endingExpiryA,
-    //       true,
-    //     );
-    //     expect(
-    //       clientB.core.expirer.get(connectionInfo.session.topic) ==
-    //           endingExpiryB,
-    //       true,
-    //     );
-    //     expect(counter, 1);
+        final endingExpiryA =
+            clientA.sessions.get(connectionInfo.session.topic)!.expiry;
+        final endingExpiryB =
+            clientB.sessions.get(connectionInfo.session.topic)!.expiry;
 
-    //     clientA.onSessionExtend.unsubscribeAll();
-    //   });
+        expect(
+          endingExpiryA >= startingExpiryA,
+          true,
+        );
+        expect(
+          endingExpiryB >= startingExpiryB,
+          true,
+        );
+        expect(
+          clientA.core.expirer.get(connectionInfo.session.topic) ==
+              endingExpiryA,
+          true,
+        );
+        expect(
+          clientB.core.expirer.get(connectionInfo.session.topic) ==
+              endingExpiryB,
+          true,
+        );
+        expect(counter, 1);
 
-    //   setUp(() async {
-    //     await clientB.sessions.set(
-    //       TEST_SESSION_EXPIRED_TOPIC,
-    //       testSessionExpired,
-    //     );
-    //     await clientB.core.expirer.set(
-    //       TEST_SESSION_EXPIRED_TOPIC.toString(),
-    //       testSessionExpired.expiry,
-    //     );
-    //   });
+        clientA.onSessionExtend.unsubscribeAll();
+      });
 
-    //   test('invalid session topic', () async {
-    //     expect(
-    //       () async => await clientB.extendSession(
-    //         topic: TEST_SESSION_INVALID_TOPIC,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'No matching key. session topic doesn\'t exist: $TEST_SESSION_INVALID_TOPIC',
-    //         ),
-    //       ),
-    //     );
+      setUp(() async {
+        await clientB.sessions.set(
+          TEST_SESSION_EXPIRED_TOPIC,
+          testSessionExpired,
+        );
+        await clientB.core.expirer.set(
+          TEST_SESSION_EXPIRED_TOPIC.toString(),
+          testSessionExpired.expiry,
+        );
+      });
 
-    //     int counter = 0;
-    //     Completer completer = Completer();
-    //     clientB.core.expirer.onExpire.subscribe((args) {
-    //       counter++;
-    //       completer.complete();
-    //     });
-    //     int counterSession = 0;
-    //     Completer completerSession = Completer();
-    //     clientB.onSessionExpire.subscribe((args) {
-    //       counterSession++;
-    //       completerSession.complete();
-    //     });
-    //     expect(
-    //       () async => await clientB.extendSession(
-    //         topic: TEST_SESSION_EXPIRED_TOPIC,
-    //       ),
-    //       throwsA(
-    //         isA<WalletConnectError>().having(
-    //           (e) => e.message,
-    //           'message',
-    //           'Expired. session topic: $TEST_SESSION_EXPIRED_TOPIC',
-    //         ),
-    //       ),
-    //     );
+      test('invalid session topic', () async {
+        expect(
+          () async => await clientB.extendSession(
+            topic: TEST_SESSION_INVALID_TOPIC,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'No matching key. session topic doesn\'t exist: $TEST_SESSION_INVALID_TOPIC',
+            ),
+          ),
+        );
 
-    //     // await Future.delayed(Duration(milliseconds: 150));
-    //     await completer.future;
-    //     await completerSession.future;
+        int counter = 0;
+        Completer completer = Completer();
+        clientB.core.expirer.onExpire.subscribe((args) {
+          counter++;
+          completer.complete();
+        });
+        int counterSession = 0;
+        Completer completerSession = Completer();
+        clientB.onSessionExpire.subscribe((args) {
+          counterSession++;
+          completerSession.complete();
+        });
+        expect(
+          () async => await clientB.extendSession(
+            topic: TEST_SESSION_EXPIRED_TOPIC,
+          ),
+          throwsA(
+            isA<WalletConnectError>().having(
+              (e) => e.message,
+              'message',
+              'Expired. session topic: $TEST_SESSION_EXPIRED_TOPIC',
+            ),
+          ),
+        );
 
-    //     expect(
-    //       clientB.sessions.has(
-    //         TEST_SESSION_EXPIRED_TOPIC,
-    //       ),
-    //       false,
-    //     );
-    //     expect(counter, 1);
-    //     expect(counterSession, 1);
-    //     clientB.core.expirer.onExpire.unsubscribeAll();
-    //     clientB.onSessionExpire.unsubscribeAll();
-    //   });
-    // });
+        // await Future.delayed(Duration(milliseconds: 150));
+        await completer.future;
+        await completerSession.future;
+
+        expect(
+          clientB.sessions.has(
+            TEST_SESSION_EXPIRED_TOPIC,
+          ),
+          false,
+        );
+        expect(counter, 1);
+        expect(counterSession, 1);
+        clientB.core.expirer.onExpire.unsubscribeAll();
+        clientB.onSessionExpire.unsubscribeAll();
+      });
+    });
 
     group('request and handler', () {
       test('register a request handler and recieve method calls with it',


### PR DESCRIPTION
# Description

Resolves #39 

Fixes an issue where sendError wouldn't cause a JsonRpcError to be thrown on the receiving end.

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

Added tests for the pairing events.
Also added tests for `sendError`, more could be added.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update