### PR TITLE
Updated wallet and dapp examples to send and sign typed eth data

### DIFF
--- a/example/dapp/lib/pages/connect_page.dart
+++ b/example/dapp/lib/pages/connect_page.dart
@@ -211,14 +211,24 @@ class ConnectPageState extends State<ConnectPage> {
       );
 
       debugPrint('Awaiting authentication response');
-      await authRes.completer.future;
+      final authResponse = await authRes.completer.future;
 
-      showPlatformToast(
-        child: const Text(
-          StringConstants.authSucceeded,
-        ),
-        context: context,
-      );
+      if (authResponse.error != null) {
+        debugPrint('Authentication failed: ${authResponse.error}');
+        await showPlatformToast(
+          child: const Text(
+            StringConstants.authFailed,
+          ),
+          context: context,
+        );
+      } else {
+        showPlatformToast(
+          child: const Text(
+            StringConstants.authSucceeded,
+          ),
+          context: context,
+        );
+      }
 
       if (_shouldDismissQrCode) {
         // ignore: use_build_context_synchronously

--- a/example/dapp/lib/utils/crypto/eip155.dart
+++ b/example/dapp/lib/utils/crypto/eip155.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
 import 'package:walletconnect_flutter_v2_dapp/models/eth/ethereum_transaction.dart';
 import 'package:walletconnect_flutter_v2_dapp/utils/test_data.dart';
@@ -46,8 +48,8 @@ class EIP155 {
     EIP155Methods.personalSign: 'personal_sign',
     EIP155Methods.ethSign: 'eth_sign',
     EIP155Methods.ethSignTransaction: 'eth_signTransaction',
-    // EIP155Methods.ethSignTypedData: 'eth_signTypedData',
-    // EIP155Methods.ethSendTransaction: 'eth_sendTransaction',
+    EIP155Methods.ethSignTypedData: 'eth_signTypedData',
+    EIP155Methods.ethSendTransaction: 'eth_sendTransaction',
   };
 
   static final Map<EIP155Events, String> events = {
@@ -85,7 +87,7 @@ class EIP155 {
           topic: topic,
           chainId: chainId,
           address: address,
-          data: testSignTypedData(address),
+          data: jsonDecode(typedData),
         );
       case EIP155Methods.ethSignTransaction:
         return ethSignTransaction(
@@ -151,7 +153,7 @@ class EIP155 {
     required String topic,
     required String chainId,
     required String address,
-    required String data,
+    required Map<String, dynamic> data,
   }) async {
     return await web3App.request(
       topic: topic,

--- a/example/dapp/lib/utils/test_data.dart
+++ b/example/dapp/lib/utils/test_data.dart
@@ -36,6 +36,9 @@ String testSignTypedData(String address) => jsonEncode(
       },
     );
 
+const typedData =
+    r'''{"types":{"EIP712Domain":[{"type":"string","name":"name"},{"type":"string","name":"version"},{"type":"uint256","name":"chainId"},{"type":"address","name":"verifyingContract"}],"Part":[{"name":"account","type":"address"},{"name":"value","type":"uint96"}],"Mint721":[{"name":"tokenId","type":"uint256"},{"name":"tokenURI","type":"string"},{"name":"creators","type":"Part[]"},{"name":"royalties","type":"Part[]"}]},"domain":{"name":"Mint721","version":"1","chainId":4,"verifyingContract":"0x2547760120aed692eb19d22a5d9ccfe0f7872fce"},"primaryType":"Mint721","message":{"@type":"ERC721","contract":"0x2547760120aed692eb19d22a5d9ccfe0f7872fce","tokenId":"1","uri":"ipfs://ipfs/hash","creators":[{"account":"0xc5eac3488524d577a1495492599e8013b1f91efa","value":10000}],"royalties":[],"tokenURI":"ipfs://ipfs/hash"}}''';
+
 /// KADENA ///
 
 SignRequest createSignRequest({


### PR DESCRIPTION
# Description

Updated eth and dapp examples to have full range of eth signature types

## How Has This Been Tested?

Manual testing by launching dapp and wallet and testing them.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update