### PR TITLE
Adds support for parsing V1 URIs

### DIFF
--- a/lib/apis/core/pairing/pairing.dart
+++ b/lib/apis/core/pairing/pairing.dart
@@ -134,9 +134,16 @@ class Pairing implements IPairing {
       WalletConnectConstants.FIVE_MINUTES,
     );
     final URIParseResult parsedUri = WalletConnectUtils.parseUri(uri);
+    if (parsedUri.version != URIVersion.v2) {
+      throw Errors.getInternalError(
+        Errors.MISSING_OR_INVALID,
+        context: 'URI is not WalletConnect version 2 URI',
+      );
+    }
+
     final String topic = parsedUri.topic;
-    final Relay relay = parsedUri.relay;
-    final String symKey = parsedUri.symKey;
+    final Relay relay = parsedUri.v2Data!.relay;
+    final String symKey = parsedUri.v2Data!.symKey;
     final PairingInfo pairing = PairingInfo(
       topic: topic,
       expiry: expiry,
@@ -146,7 +153,7 @@ class Pairing implements IPairing {
 
     try {
       JsonRpcUtils.validateMethods(
-        parsedUri.methods,
+        parsedUri.v2Data!.methods,
         routerMapRequest.values.toList(),
       );
     } on WalletConnectError catch (e) {

--- a/lib/apis/models/uri_parse_result.dart
+++ b/lib/apis/models/uri_parse_result.dart
@@ -1,17 +1,42 @@
 import 'package:walletconnect_flutter_v2/apis/core/relay_client/relay_client_models.dart';
 
+enum URIVersion {
+  v1,
+  v2,
+}
+
 class URIParseResult {
   final String protocol;
-  final String? version;
   final String topic;
-  final String symKey;
-  final Relay relay;
-  final List<String> methods;
+  final URIVersion? version;
+  final URIV1ParsedData? v1Data;
+  final URIV2ParsedData? v2Data;
 
   URIParseResult({
     required this.protocol,
     required this.version,
     required this.topic,
+    this.v1Data,
+    this.v2Data,
+  });
+}
+
+class URIV1ParsedData {
+  final String key;
+  final String bridge;
+
+  URIV1ParsedData({
+    required this.key,
+    required this.bridge,
+  });
+}
+
+class URIV2ParsedData {
+  final String symKey;
+  final Relay relay;
+  final List<String> methods;
+
+  URIV2ParsedData({
     required this.symKey,
     required this.relay,
     required this.methods,

--- a/lib/apis/utils/walletconnect_utils.dart
+++ b/lib/apis/utils/walletconnect_utils.dart
@@ -96,20 +96,46 @@ class WalletConnectUtils {
     if (methods.length == 1 && methods[0].isEmpty) {
       methods = [];
     }
+    final URIVersion? version;
+    switch (splitParams[1]) {
+      case '1':
+        version = URIVersion.v1;
+        break;
+      case '2':
+        version = URIVersion.v2;
+        break;
+      default:
+        version = null;
+    }
+    final URIV1ParsedData? v1Data;
+    final URIV2ParsedData? v2Data;
+    if (version == URIVersion.v1) {
+      v1Data = URIV1ParsedData(
+        key: uri.queryParameters['key']!,
+        bridge: uri.queryParameters['bridge']!,
+      );
+      v2Data = null;
+    } else {
+      v1Data = null;
+      v2Data = URIV2ParsedData(
+        symKey: uri.queryParameters['symKey']!,
+        relay: Relay(
+          uri.queryParameters['relay-protocol']!,
+          data: uri.queryParameters.containsKey('relay-data')
+              ? uri.queryParameters['relay-data']
+              : null,
+        ),
+        methods: methods,
+      );
+    }
+
     URIParseResult ret = URIParseResult(
       protocol: protocol,
-      version: splitParams[1],
+      version: version,
       topic: splitParams[0],
-      symKey: uri.queryParameters['symKey']!,
-      relay: Relay(
-        uri.queryParameters['relay-protocol']!,
-        data: uri.queryParameters.containsKey('relay-data')
-            ? uri.queryParameters['relay-data']
-            : null,
-      ),
-      methods: methods,
+      v1Data: v1Data,
+      v2Data: v2Data,
     );
-    // print(ret);
     return ret;
   }
 

--- a/test/auth_api/auth_client_test.dart
+++ b/test/auth_api/auth_client_test.dart
@@ -382,17 +382,17 @@ void runTests({
         expect(response.uri != null, true);
         URIParseResult parsed = WalletConnectUtils.parseUri(response.uri!);
         expect(parsed.protocol, 'wc');
-        expect(parsed.version, '2');
+        expect(parsed.version, URIVersion.v2);
         expect(parsed.topic, response.pairingTopic);
-        expect(parsed.relay.protocol, 'irn');
+        expect(parsed.v2Data!.relay.protocol, 'irn');
         if (clientA is IWeb3App) {
-          expect(parsed.methods.length, 3);
-          expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
-          expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
-          expect(parsed.methods[2], MethodConstants.WC_AUTH_REQUEST);
+          expect(parsed.v2Data!.methods.length, 3);
+          expect(parsed.v2Data!.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+          expect(parsed.v2Data!.methods[1], MethodConstants.WC_SESSION_REQUEST);
+          expect(parsed.v2Data!.methods[2], MethodConstants.WC_AUTH_REQUEST);
         } else {
-          expect(parsed.methods.length, 1);
-          expect(parsed.methods[0], MethodConstants.WC_AUTH_REQUEST);
+          expect(parsed.v2Data!.methods.length, 1);
+          expect(parsed.v2Data!.methods[0], MethodConstants.WC_AUTH_REQUEST);
         }
 
         response = await clientA.requestAuth(
@@ -403,9 +403,9 @@ void runTests({
         expect(response.uri != null, true);
         parsed = WalletConnectUtils.parseUri(response.uri!);
         expect(parsed.protocol, 'wc');
-        expect(parsed.version, '2');
-        expect(parsed.relay.protocol, 'irn');
-        expect(parsed.methods.length, 0);
+        expect(parsed.version, URIVersion.v2);
+        expect(parsed.v2Data!.relay.protocol, 'irn');
+        expect(parsed.v2Data!.methods.length, 0);
       });
 
       test('invalid request params', () async {

--- a/test/core_api/pairing_test.dart
+++ b/test/core_api/pairing_test.dart
@@ -42,14 +42,14 @@ void main() {
 
     URIParseResult parsed = WalletConnectUtils.parseUri(response);
     expect(parsed.protocol, 'wc');
-    expect(parsed.version, '2');
+    expect(parsed.version, URIVersion.v2);
     expect(parsed.topic, 'abc');
-    expect(parsed.symKey, 'xyz');
-    expect(parsed.relay.protocol, 'irn');
-    expect(parsed.methods.length, 3);
-    expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
-    expect(parsed.methods[1], MethodConstants.WC_AUTH_REQUEST);
-    expect(parsed.methods[2], 'wc_authBatchRequest');
+    expect(parsed.v2Data!.symKey, 'xyz');
+    expect(parsed.v2Data!.relay.protocol, 'irn');
+    expect(parsed.v2Data!.methods.length, 3);
+    expect(parsed.v2Data!.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+    expect(parsed.v2Data!.methods[1], MethodConstants.WC_AUTH_REQUEST);
+    expect(parsed.v2Data!.methods[2], 'wc_authBatchRequest');
 
     response = WalletConnectUtils.formatUri(
       protocol: 'wc',
@@ -66,20 +66,31 @@ void main() {
 
     parsed = WalletConnectUtils.parseUri(response);
     expect(parsed.protocol, 'wc');
-    expect(parsed.version, '2');
+    expect(parsed.version, URIVersion.v2);
     expect(parsed.topic, 'abc');
-    expect(parsed.symKey, 'xyz');
-    expect(parsed.relay.protocol, 'irn');
-    expect(parsed.methods.length, 0);
+    expect(parsed.v2Data!.symKey, 'xyz');
+    expect(parsed.v2Data!.relay.protocol, 'irn');
+    expect(parsed.v2Data!.methods.length, 0);
 
     // Can parse URI with missing methods param
     response = Uri.parse('wc:abc@2?relay-protocol=irn&symKey=xyz');
     expect(parsed.protocol, 'wc');
-    expect(parsed.version, '2');
+    expect(parsed.version, URIVersion.v2);
     expect(parsed.topic, 'abc');
-    expect(parsed.symKey, 'xyz');
-    expect(parsed.relay.protocol, 'irn');
-    expect(parsed.methods.length, 0);
+    expect(parsed.v2Data!.symKey, 'xyz');
+    expect(parsed.v2Data!.relay.protocol, 'irn');
+    expect(parsed.v2Data!.methods.length, 0);
+
+    // V1 testing
+    parsed = WalletConnectUtils.parseUri(Uri.parse(
+        'wc:00e46b69-d0cc-4b3e-b6a2-cee442f97188@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=91303dedf64285cbbaf9120f6e9d160a5c8aa3deb67017a3874cd272323f48ae'));
+    expect(parsed.protocol, 'wc');
+    expect(parsed.version, URIVersion.v1);
+    expect(parsed.topic, '00e46b69-d0cc-4b3e-b6a2-cee442f97188');
+    expect(parsed.v2Data, null);
+    expect(parsed.v1Data!.key,
+        '91303dedf64285cbbaf9120f6e9d160a5c8aa3deb67017a3874cd272323f48ae');
+    expect(parsed.v1Data!.bridge, 'https://bridge.walletconnect.org');
   });
 
   group('history', () {
@@ -146,12 +157,12 @@ void main() {
 
         final URIParseResult parsed = WalletConnectUtils.parseUri(response.uri);
         expect(parsed.protocol, 'wc');
-        expect(parsed.version, '2');
-        expect(parsed.relay.protocol, 'irn');
-        expect(parsed.methods.length, 3);
-        expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
-        expect(parsed.methods[1], MethodConstants.WC_AUTH_REQUEST);
-        expect(parsed.methods[2], 'wc_authBatchRequest');
+        expect(parsed.version, URIVersion.v2);
+        expect(parsed.v2Data!.relay.protocol, 'irn');
+        expect(parsed.v2Data!.methods.length, 3);
+        expect(parsed.v2Data!.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+        expect(parsed.v2Data!.methods[1], MethodConstants.WC_AUTH_REQUEST);
+        expect(parsed.v2Data!.methods[2], 'wc_authBatchRequest');
       });
     });
 

--- a/test/sign_api/tests/sign_client_helpers.dart
+++ b/test/sign_api/tests/sign_client_helpers.dart
@@ -162,7 +162,7 @@ class SignClientHelpers {
       pairingA = a.pairings.get(uriParams.topic);
       expect(pairingA != null, true);
       expect(pairingA!.topic, uriParams.topic);
-      expect(pairingA.relay.protocol, uriParams.relay.protocol);
+      expect(pairingA.relay.protocol, uriParams.v2Data!.relay.protocol);
 
       // If we recieved no pairing topic, then we want to create one
       // e.g. we pair from b to a using the uri created from the connect
@@ -348,7 +348,7 @@ class SignClientHelpers {
       pairingA = a.pairings.get(uriParams.topic);
       expect(pairingA != null, true);
       expect(pairingA!.topic, uriParams.topic);
-      expect(pairingA.relay.protocol, uriParams.relay.protocol);
+      expect(pairingA.relay.protocol, uriParams.v2Data!.relay.protocol);
 
       // If we recieved no pairing topic, then we want to create one
       // e.g. we pair from b to a using the uri created from the connect

--- a/test/sign_api/tests/sign_connect.dart
+++ b/test/sign_api/tests/sign_connect.dart
@@ -43,18 +43,18 @@ void signConnect({
       expect(response.uri != null, true);
       URIParseResult parsed = WalletConnectUtils.parseUri(response.uri!);
       expect(parsed.protocol, 'wc');
-      expect(parsed.version, '2');
+      expect(parsed.version, URIVersion.v2);
       expect(parsed.topic, response.pairingTopic);
-      expect(parsed.relay.protocol, 'irn');
+      expect(parsed.v2Data!.relay.protocol, 'irn');
       if (clientA is IWeb3App) {
-        expect(parsed.methods.length, 3);
-        expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
-        expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
-        expect(parsed.methods[2], MethodConstants.WC_AUTH_REQUEST);
+        expect(parsed.v2Data!.methods.length, 3);
+        expect(parsed.v2Data!.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+        expect(parsed.v2Data!.methods[1], MethodConstants.WC_SESSION_REQUEST);
+        expect(parsed.v2Data!.methods[2], MethodConstants.WC_AUTH_REQUEST);
       } else {
-        expect(parsed.methods.length, 2);
-        expect(parsed.methods[0], MethodConstants.WC_SESSION_PROPOSE);
-        expect(parsed.methods[1], MethodConstants.WC_SESSION_REQUEST);
+        expect(parsed.v2Data!.methods.length, 2);
+        expect(parsed.v2Data!.methods[0], MethodConstants.WC_SESSION_PROPOSE);
+        expect(parsed.v2Data!.methods[1], MethodConstants.WC_SESSION_REQUEST);
       }
 
       response = await clientA.connect(
@@ -65,9 +65,9 @@ void signConnect({
       expect(response.uri != null, true);
       parsed = WalletConnectUtils.parseUri(response.uri!);
       expect(parsed.protocol, 'wc');
-      expect(parsed.version, '2');
-      expect(parsed.relay.protocol, 'irn');
-      expect(parsed.methods.length, 0);
+      expect(parsed.version, URIVersion.v2);
+      expect(parsed.v2Data!.relay.protocol, 'irn');
+      expect(parsed.v2Data!.methods.length, 0);
     });
 
     test('invalid topic', () {

--- a/test/web3wallet/web3wallet_helpers.dart
+++ b/test/web3wallet/web3wallet_helpers.dart
@@ -142,7 +142,7 @@ class Web3WalletHelpers {
       pairingA = a.pairings.get(uriParams.topic);
       expect(pairingA != null, true);
       expect(pairingA!.topic, uriParams.topic);
-      expect(pairingA.relay.protocol, uriParams.relay.protocol);
+      expect(pairingA.relay.protocol, uriParams.v2Data!.relay.protocol);
 
       // If we recieved no pairing topic, then we want to create one
       // e.g. we pair from b to a using the uri created from the connect


### PR DESCRIPTION
# Adds support for parsing V1 URIs
Resolves #59 

`WalletConnectUtils.parseUri` has been updated to accommodate V1 URIs.

* `URIParseResult` class has been changed (this makes it a breaking change).
* `version` is now an enum `URIVersion`.
* parsed data parameters have been moved to `URIV2ParsedData` for V2 URIs and `URIV2ParsedData` for V1 URIs.

```dart
class URIParseResult {
  final String protocol;
  final String topic;
  final URIVersion? version;
  final URIV1ParsedData? v1Data;
  final URIV2ParsedData? v2Data;
}

class URIV1ParsedData {
  final String key;
  final String bridge;
}

class URIV2ParsedData {
  final String symKey;
  final Relay relay;
  final List<String> methods;
}
```

## How Has This Been Tested?

Unit tests have been fixed and more have been added for V1.

## Due Dilligence

* [x] Breaking change
* [ ] Requires a documentation update