### PR TITLE
example dapp - bumped qr_flutter version, fixed QrImage widget error

### DIFF
--- a/example/dapp/lib/pages/connect_page.dart
+++ b/example/dapp/lib/pages/connect_page.dart
@@ -272,7 +272,8 @@ class ConnectPageState extends State<ConnectPage> {
             child: Center(
               child: Column(
                 children: [
-                  QrImage(
+                  QrImageView(
+                    size: 100.0,
                     data: response.uri!.toString(),
                   ),
                   const SizedBox(

--- a/example/dapp/pubspec.yaml
+++ b/example/dapp/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  qr_flutter: ^4.0.0
+  qr_flutter: ^4.1.0
   json_annotation: ^4.8.0
   walletconnect_flutter_v2:
     path: ../..


### PR DESCRIPTION
# Description
- bumped qr_flutter package to 4.1.0 in example dapp
- fixed QrImage widget error in example dapp

## How Has This Been Tested?
Recreate:
Run example dapp

Error screenshot:
<img width="660" alt="Screenshot 2023-05-19 at 1 05 53 PM" src="https://github.com/WalletConnect/WalletConnectFlutterV2/assets/17320471/8133f533-5900-4cc1-a37d-5e059a5948d4">

Fix screenshot:
<img width="320" alt="Screenshot 2023-05-19 at 1 15 21 PM" src="https://github.com/WalletConnect/WalletConnectFlutterV2/assets/17320471/8751f95c-ccc2-4140-99cd-f70150df21b2">

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update