### PR TITLE
Enable `explicit_to_json` option for json_serializable

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          explicit_to_json: true

--- a/example/dapp/lib/models/solana/solana_sign_transaction.g.dart
+++ b/example/dapp/lib/models/solana/solana_sign_transaction.g.dart
@@ -21,7 +21,7 @@ Map<String, dynamic> _$SolanaSignTransactionToJson(
     <String, dynamic>{
       'feePayer': instance.feePayer,
       'recentBlockhash': instance.recentBlockhash,
-      'instructions': instance.instructions,
+      'instructions': instance.instructions.map((e) => e.toJson()).toList(),
     };
 
 SolanaInstruction _$SolanaInstructionFromJson(Map<String, dynamic> json) =>
@@ -36,7 +36,7 @@ SolanaInstruction _$SolanaInstructionFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$SolanaInstructionToJson(SolanaInstruction instance) =>
     <String, dynamic>{
       'programId': instance.programId,
-      'keys': instance.keys,
+      'keys': instance.keys.map((e) => e.toJson()).toList(),
       'data': instance.data,
     };
 

--- a/example/wallet/lib/models/solana/solana_sign_transaction.g.dart
+++ b/example/wallet/lib/models/solana/solana_sign_transaction.g.dart
@@ -21,7 +21,7 @@ Map<String, dynamic> _$SolanaSignTransactionToJson(
     <String, dynamic>{
       'feePayer': instance.feePayer,
       'recentBlockhash': instance.recentBlockhash,
-      'instructions': instance.instructions,
+      'instructions': instance.instructions.map((e) => e.toJson()).toList(),
     };
 
 SolanaInstruction _$SolanaInstructionFromJson(Map<String, dynamic> json) =>
@@ -36,7 +36,7 @@ SolanaInstruction _$SolanaInstructionFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$SolanaInstructionToJson(SolanaInstruction instance) =>
     <String, dynamic>{
       'programId': instance.programId,
-      'keys': instance.keys,
+      'keys': instance.keys.map((e) => e.toJson()).toList(),
       'data': instance.data,
     };
 

--- a/lib/apis/auth_api/models/auth_client_models.g.dart
+++ b/lib/apis/auth_api/models/auth_client_models.g.dart
@@ -175,9 +175,9 @@ Cacao _$CacaoFromJson(Map<String, dynamic> json) => Cacao(
     );
 
 Map<String, dynamic> _$CacaoToJson(Cacao instance) => <String, dynamic>{
-      'h': instance.h,
-      'p': instance.p,
-      's': instance.s,
+      'h': instance.h.toJson(),
+      'p': instance.p.toJson(),
+      's': instance.s.toJson(),
     };
 
 StoredCacao _$StoredCacaoFromJson(Map<String, dynamic> json) => StoredCacao(
@@ -190,9 +190,9 @@ StoredCacao _$StoredCacaoFromJson(Map<String, dynamic> json) => StoredCacao(
 
 Map<String, dynamic> _$StoredCacaoToJson(StoredCacao instance) =>
     <String, dynamic>{
-      'h': instance.h,
-      'p': instance.p,
-      's': instance.s,
+      'h': instance.h.toJson(),
+      'p': instance.p.toJson(),
+      's': instance.s.toJson(),
       'id': instance.id,
       'pairingTopic': instance.pairingTopic,
     };
@@ -211,6 +211,6 @@ Map<String, dynamic> _$PendingAuthRequestToJson(PendingAuthRequest instance) =>
     <String, dynamic>{
       'id': instance.id,
       'pairingTopic': instance.pairingTopic,
-      'metadata': instance.metadata,
-      'cacaoPayload': instance.cacaoPayload,
+      'metadata': instance.metadata.toJson(),
+      'cacaoPayload': instance.cacaoPayload.toJson(),
     };

--- a/lib/apis/auth_api/models/json_rpc_models.g.dart
+++ b/lib/apis/auth_api/models/json_rpc_models.g.dart
@@ -18,8 +18,8 @@ WcAuthRequestRequest _$WcAuthRequestRequestFromJson(
 Map<String, dynamic> _$WcAuthRequestRequestToJson(
         WcAuthRequestRequest instance) =>
     <String, dynamic>{
-      'payloadParams': instance.payloadParams,
-      'requester': instance.requester,
+      'payloadParams': instance.payloadParams.toJson(),
+      'requester': instance.requester.toJson(),
     };
 
 WcAuthRequestResult _$WcAuthRequestResultFromJson(Map<String, dynamic> json) =>
@@ -30,5 +30,5 @@ WcAuthRequestResult _$WcAuthRequestResultFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$WcAuthRequestResultToJson(
         WcAuthRequestResult instance) =>
     <String, dynamic>{
-      'cacao': instance.cacao,
+      'cacao': instance.cacao.toJson(),
     };

--- a/lib/apis/core/pairing/utils/pairing_models.g.dart
+++ b/lib/apis/core/pairing/utils/pairing_models.g.dart
@@ -21,9 +21,9 @@ Map<String, dynamic> _$PairingInfoToJson(PairingInfo instance) =>
     <String, dynamic>{
       'topic': instance.topic,
       'expiry': instance.expiry,
-      'relay': instance.relay,
+      'relay': instance.relay.toJson(),
       'active': instance.active,
-      'peerMetadata': instance.peerMetadata,
+      'peerMetadata': instance.peerMetadata?.toJson(),
     };
 
 PairingMetadata _$PairingMetadataFromJson(Map<String, dynamic> json) =>
@@ -43,7 +43,7 @@ Map<String, dynamic> _$PairingMetadataToJson(PairingMetadata instance) =>
       'description': instance.description,
       'url': instance.url,
       'icons': instance.icons,
-      'redirect': instance.redirect,
+      'redirect': instance.redirect?.toJson(),
     };
 
 Redirect _$RedirectFromJson(Map<String, dynamic> json) => Redirect(

--- a/lib/apis/models/basic_models.g.dart
+++ b/lib/apis/models/basic_models.g.dart
@@ -39,5 +39,5 @@ ConnectionMetadata _$ConnectionMetadataFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$ConnectionMetadataToJson(ConnectionMetadata instance) =>
     <String, dynamic>{
       'publicKey': instance.publicKey,
-      'metadata': instance.metadata,
+      'metadata': instance.metadata.toJson(),
     };

--- a/lib/apis/models/json_rpc_response.g.dart
+++ b/lib/apis/models/json_rpc_response.g.dart
@@ -26,7 +26,7 @@ Map<String, dynamic> _$JsonRpcResponseToJson<T>(
     <String, dynamic>{
       'id': instance.id,
       'jsonrpc': instance.jsonrpc,
-      'error': instance.error,
+      'error': instance.error?.toJson(),
       'result': _$nullableGenericToJson(instance.result, toJsonT),
     };
 

--- a/lib/apis/sign_api/models/json_rpc_models.g.dart
+++ b/lib/apis/sign_api/models/json_rpc_models.g.dart
@@ -59,8 +59,9 @@ WcSessionProposeRequest _$WcSessionProposeRequestFromJson(
 Map<String, dynamic> _$WcSessionProposeRequestToJson(
     WcSessionProposeRequest instance) {
   final val = <String, dynamic>{
-    'relays': instance.relays,
-    'requiredNamespaces': instance.requiredNamespaces,
+    'relays': instance.relays.map((e) => e.toJson()).toList(),
+    'requiredNamespaces':
+        instance.requiredNamespaces.map((k, e) => MapEntry(k, e.toJson())),
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -69,9 +70,10 @@ Map<String, dynamic> _$WcSessionProposeRequestToJson(
     }
   }
 
-  writeNotNull('optionalNamespaces', instance.optionalNamespaces);
+  writeNotNull('optionalNamespaces',
+      instance.optionalNamespaces?.map((k, e) => MapEntry(k, e.toJson())));
   writeNotNull('sessionProperties', instance.sessionProperties);
-  val['proposer'] = instance.proposer;
+  val['proposer'] = instance.proposer.toJson();
   return val;
 }
 
@@ -85,7 +87,7 @@ WcSessionProposeResponse _$WcSessionProposeResponseFromJson(
 Map<String, dynamic> _$WcSessionProposeResponseToJson(
         WcSessionProposeResponse instance) =>
     <String, dynamic>{
-      'relay': instance.relay,
+      'relay': instance.relay.toJson(),
       'responderPublicKey': instance.responderPublicKey,
     };
 
@@ -118,8 +120,8 @@ WcSessionSettleRequest _$WcSessionSettleRequestFromJson(
 Map<String, dynamic> _$WcSessionSettleRequestToJson(
     WcSessionSettleRequest instance) {
   final val = <String, dynamic>{
-    'relay': instance.relay,
-    'namespaces': instance.namespaces,
+    'relay': instance.relay.toJson(),
+    'namespaces': instance.namespaces.map((k, e) => MapEntry(k, e.toJson())),
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -128,11 +130,13 @@ Map<String, dynamic> _$WcSessionSettleRequestToJson(
     }
   }
 
-  writeNotNull('requiredNamespaces', instance.requiredNamespaces);
-  writeNotNull('optionalNamespaces', instance.optionalNamespaces);
+  writeNotNull('requiredNamespaces',
+      instance.requiredNamespaces?.map((k, e) => MapEntry(k, e.toJson())));
+  writeNotNull('optionalNamespaces',
+      instance.optionalNamespaces?.map((k, e) => MapEntry(k, e.toJson())));
   writeNotNull('sessionProperties', instance.sessionProperties);
   val['expiry'] = instance.expiry;
-  val['controller'] = instance.controller;
+  val['controller'] = instance.controller.toJson();
   return val;
 }
 
@@ -147,7 +151,7 @@ WcSessionUpdateRequest _$WcSessionUpdateRequestFromJson(
 Map<String, dynamic> _$WcSessionUpdateRequestToJson(
         WcSessionUpdateRequest instance) =>
     <String, dynamic>{
-      'namespaces': instance.namespaces,
+      'namespaces': instance.namespaces.map((k, e) => MapEntry(k, e.toJson())),
     };
 
 WcSessionExtendRequest _$WcSessionExtendRequestFromJson(
@@ -227,7 +231,7 @@ Map<String, dynamic> _$WcSessionRequestRequestToJson(
         WcSessionRequestRequest instance) =>
     <String, dynamic>{
       'chainId': instance.chainId,
-      'request': instance.request,
+      'request': instance.request.toJson(),
     };
 
 SessionRequestParams _$SessionRequestParamsFromJson(
@@ -255,7 +259,7 @@ Map<String, dynamic> _$WcSessionEventRequestToJson(
         WcSessionEventRequest instance) =>
     <String, dynamic>{
       'chainId': instance.chainId,
-      'event': instance.event,
+      'event': instance.event.toJson(),
     };
 
 SessionEventParams _$SessionEventParamsFromJson(Map<String, dynamic> json) =>

--- a/lib/apis/sign_api/models/proposal_models.g.dart
+++ b/lib/apis/sign_api/models/proposal_models.g.dart
@@ -40,7 +40,7 @@ SessionProposal _$SessionProposalFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$SessionProposalToJson(SessionProposal instance) =>
     <String, dynamic>{
       'id': instance.id,
-      'params': instance.params,
+      'params': instance.params.toJson(),
     };
 
 ProposalData _$ProposalDataFromJson(Map<String, dynamic> json) => ProposalData(
@@ -76,10 +76,12 @@ Map<String, dynamic> _$ProposalDataToJson(ProposalData instance) {
   final val = <String, dynamic>{
     'id': instance.id,
     'expiry': instance.expiry,
-    'relays': instance.relays,
-    'proposer': instance.proposer,
-    'requiredNamespaces': instance.requiredNamespaces,
-    'optionalNamespaces': instance.optionalNamespaces,
+    'relays': instance.relays.map((e) => e.toJson()).toList(),
+    'proposer': instance.proposer.toJson(),
+    'requiredNamespaces':
+        instance.requiredNamespaces.map((k, e) => MapEntry(k, e.toJson())),
+    'optionalNamespaces':
+        instance.optionalNamespaces.map((k, e) => MapEntry(k, e.toJson())),
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -90,6 +92,7 @@ Map<String, dynamic> _$ProposalDataToJson(ProposalData instance) {
 
   writeNotNull('sessionProperties', instance.sessionProperties);
   val['pairingTopic'] = instance.pairingTopic;
-  writeNotNull('generatedNamespaces', instance.generatedNamespaces);
+  writeNotNull('generatedNamespaces',
+      instance.generatedNamespaces?.map((k, e) => MapEntry(k, e.toJson())));
   return val;
 }

--- a/lib/apis/sign_api/models/session_models.g.dart
+++ b/lib/apis/sign_api/models/session_models.g.dart
@@ -53,11 +53,11 @@ Map<String, dynamic> _$SessionDataToJson(SessionData instance) {
   final val = <String, dynamic>{
     'topic': instance.topic,
     'pairingTopic': instance.pairingTopic,
-    'relay': instance.relay,
+    'relay': instance.relay.toJson(),
     'expiry': instance.expiry,
     'acknowledged': instance.acknowledged,
     'controller': instance.controller,
-    'namespaces': instance.namespaces,
+    'namespaces': instance.namespaces.map((k, e) => MapEntry(k, e.toJson())),
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -66,11 +66,13 @@ Map<String, dynamic> _$SessionDataToJson(SessionData instance) {
     }
   }
 
-  writeNotNull('requiredNamespaces', instance.requiredNamespaces);
-  writeNotNull('optionalNamespaces', instance.optionalNamespaces);
+  writeNotNull('requiredNamespaces',
+      instance.requiredNamespaces?.map((k, e) => MapEntry(k, e.toJson())));
+  writeNotNull('optionalNamespaces',
+      instance.optionalNamespaces?.map((k, e) => MapEntry(k, e.toJson())));
   writeNotNull('sessionProperties', instance.sessionProperties);
-  val['self'] = instance.self;
-  val['peer'] = instance.peer;
+  val['self'] = instance.self.toJson();
+  val['peer'] = instance.peer.toJson();
   return val;
 }
 


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

The default options generated by `json_serializable` do not call the `toJson` method for nested objects. If we only use `jsonEncode` for serialization, it can meet common needs. However, in many cases, we need a purely serializable `Map` object, such as when using other kv databases.

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ x ] Breaking change
* [ x ] Requires a documentation update