### PR TITLE
Downgrade the minimum required version of the dart SDK

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.7
 repository: https://github.com/WalletConnect/WalletConnectFlutterV2
 
 environment:
-  sdk: '>=3.0.1 <4.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Downgrading the minimum required version of SDK can improve compatibility with more versions. Using the latest version of SDK may cause applications using older SDK environments to be unable to integrate the latest modifications.

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ x ] Breaking change
* [ x ] Requires a documentation update