### PR TITLE
add chainId to registerRequestHandler handler

### DIFF
--- a/example/wallet/lib/dependencies/chains/evm_service.dart
+++ b/example/wallet/lib/dependencies/chains/evm_service.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
-import 'package:flutter/foundation.dart';
-// ignore: depend_on_referenced_packages
-import 'package:http/http.dart' as http;
+
 import 'package:convert/convert.dart';
 import 'package:eth_sig_util/eth_sig_util.dart';
+import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
+// ignore: depend_on_referenced_packages
+import 'package:http/http.dart' as http;
+import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine_wallet.dart';
 import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
 import 'package:walletconnect_flutter_v2_wallet/dependencies/bottom_sheet/i_bottom_sheet_service.dart';
 import 'package:walletconnect_flutter_v2_wallet/dependencies/deep_link_handler.dart';
@@ -77,7 +79,7 @@ class EVMService {
       );
     }
     // Supported methods
-    Map<String, dynamic Function(String, dynamic)> methodsHandlers = {
+    Map<String, RequestHandler> methodsHandlers = {
       'personal_sign': personalSign,
       'eth_sign': ethSign,
       'eth_signTransaction': ethSignTransaction,
@@ -98,7 +100,8 @@ class EVMService {
     }
   }
 
-  Future<dynamic> personalSign(String topic, dynamic parameters) async {
+  Future<dynamic> personalSign(
+      String topic, String chainId, dynamic parameters) async {
     debugPrint('[$runtimeType] personalSign request: $parameters');
     dynamic result;
     final data = EthUtils.getDataFromParamsList(parameters);
@@ -134,7 +137,8 @@ class EVMService {
     return result;
   }
 
-  Future<dynamic> ethSign(String topic, dynamic parameters) async {
+  Future<dynamic> ethSign(
+      String topic, String chainId, dynamic parameters) async {
     debugPrint('[$runtimeType] ethSign request: $parameters');
     dynamic result;
     final data = EthUtils.getDataFromParamsList(parameters);
@@ -170,7 +174,8 @@ class EVMService {
     return result;
   }
 
-  Future<dynamic> ethSignTypedData(String topic, dynamic parameters) async {
+  Future<dynamic> ethSignTypedData(
+      String topic, String chainId, dynamic parameters) async {
     debugPrint('[$runtimeType] ethSignTypedData request: $parameters');
     dynamic result;
     final data = parameters[1] as String;
@@ -201,7 +206,8 @@ class EVMService {
     return result;
   }
 
-  Future<void> switchChain(String topic, dynamic parameters) async {
+  Future<void> switchChain(
+      String topic, String chainId, dynamic parameters) async {
     debugPrint('received switchChain request: $topic $parameters');
     final params = (parameters as List).first as Map<String, dynamic>;
     final hexChainId = params['chainId'].toString().replaceFirst('0x', '');
@@ -217,7 +223,8 @@ class EVMService {
     );
   }
 
-  Future<dynamic> ethSignTransaction(String topic, dynamic parameters) async {
+  Future<dynamic> ethSignTransaction(
+      String topic, String chainId, dynamic parameters) async {
     debugPrint('[$runtimeType] ethSignTransaction request: $parameters');
     dynamic result;
 
@@ -258,7 +265,8 @@ class EVMService {
     return result;
   }
 
-  Future<dynamic> ethSendTransaction(String topic, dynamic parameters) async {
+  Future<dynamic> ethSendTransaction(
+      String topic, String chainId, dynamic parameters) async {
     debugPrint('[$runtimeType] ethSendTransaction request: $parameters');
     dynamic result;
 
@@ -297,7 +305,8 @@ class EVMService {
     return result;
   }
 
-  Future<void> addChain(String topic, dynamic parameters) async {
+  Future<void> addChain(
+      String topic, String chainId, dynamic parameters) async {
     debugPrint('received addChain request: $topic $parameters');
   }
 

--- a/lib/apis/sign_api/i_sign_client.dart
+++ b/lib/apis/sign_api/i_sign_client.dart
@@ -1,5 +1,6 @@
 import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sessions.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine_wallet.dart';
 import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
 
 abstract class ISignClient {
@@ -62,7 +63,7 @@ abstract class ISignClient {
   void registerRequestHandler({
     required String chainId,
     required String method,
-    dynamic Function(String, dynamic)? handler,
+    RequestHandler? handler,
   });
   Future<void> respond({
     required String topic,

--- a/lib/apis/sign_api/i_sign_engine_wallet.dart
+++ b/lib/apis/sign_api/i_sign_engine_wallet.dart
@@ -9,6 +9,12 @@ import 'package:walletconnect_flutter_v2/apis/sign_api/models/session_models.dar
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_events.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_models.dart';
 
+typedef RequestHandler = dynamic Function(
+  String topic,
+  String chainId,
+  dynamic params,
+);
+
 abstract class ISignEngineWallet extends ISignEngineCommon {
   abstract final Event<SessionProposalEvent> onSessionProposal;
   abstract final Event<SessionProposalErrorEvent> onSessionProposalError;
@@ -36,7 +42,7 @@ abstract class ISignEngineWallet extends ISignEngineCommon {
   void registerRequestHandler({
     required String chainId,
     required String method,
-    dynamic Function(String, dynamic)? handler,
+    RequestHandler? handler,
   });
   Future<void> respondSessionRequest({
     required String topic,

--- a/lib/apis/sign_api/sign_client.dart
+++ b/lib/apis/sign_api/sign_client.dart
@@ -1,23 +1,24 @@
 import 'package:event/event.dart';
 import 'package:walletconnect_flutter_v2/apis/core/core.dart';
+import 'package:walletconnect_flutter_v2/apis/core/i_core.dart';
+import 'package:walletconnect_flutter_v2/apis/core/pairing/i_pairing_store.dart';
+import 'package:walletconnect_flutter_v2/apis/core/pairing/utils/pairing_models.dart';
+import 'package:walletconnect_flutter_v2/apis/core/relay_client/relay_client_models.dart';
 import 'package:walletconnect_flutter_v2/apis/core/store/generic_store.dart';
 import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
-import 'package:walletconnect_flutter_v2/apis/core/pairing/i_pairing_store.dart';
-import 'package:walletconnect_flutter_v2/apis/core/relay_client/relay_client_models.dart';
 import 'package:walletconnect_flutter_v2/apis/models/basic_models.dart';
 import 'package:walletconnect_flutter_v2/apis/models/json_rpc_response.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine.dart';
-import 'package:walletconnect_flutter_v2/apis/core/pairing/utils/pairing_models.dart';
-import 'package:walletconnect_flutter_v2/apis/core/i_core.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sessions.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_client.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine_wallet.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/json_rpc_models.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/proposal_models.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_models.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_events.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/session_models.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_events.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_models.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/sessions.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
 import 'package:walletconnect_flutter_v2/apis/utils/constants.dart';
 import 'package:walletconnect_flutter_v2/apis/utils/log_level.dart';
 import 'package:web3dart/web3dart.dart';
@@ -233,7 +234,7 @@ class SignClient implements ISignClient {
   void registerRequestHandler({
     required String chainId,
     required String method,
-    void Function(String, dynamic)? handler,
+    RequestHandler? handler,
   }) {
     try {
       return engine.registerRequestHandler(

--- a/lib/apis/sign_api/sign_engine.dart
+++ b/lib/apis/sign_api/sign_engine.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 
+import 'package:http/http.dart' as http;
 import 'package:walletconnect_flutter_v2/apis/core/pairing/utils/json_rpc_utils.dart';
 import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
 import 'package:walletconnect_flutter_v2/apis/core/verify/models/verify_context.dart';
 import 'package:walletconnect_flutter_v2/apis/models/json_rpc_request.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sessions.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine_wallet.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/utils/custom_credentials.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/utils/sign_api_validator_utils.dart';
 import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
@@ -439,13 +440,13 @@ class SignEngine implements ISignEngine {
   }
 
   /// Maps a request using chainId:method to its handler
-  final Map<String, dynamic Function(String, dynamic)?> _methodHandlers = {};
+  final Map<String, RequestHandler?> _methodHandlers = {};
 
   @override
   void registerRequestHandler({
     required String chainId,
     required String method,
-    dynamic Function(String, dynamic)? handler,
+    RequestHandler? handler,
   }) {
     _methodHandlers[_getRegisterKey(chainId, method)] = handler;
   }
@@ -1284,6 +1285,7 @@ class SignEngine implements ISignEngine {
           try {
             final result = await handler(
               topic,
+              request.chainId,
               request.request.params,
             );
             await core.pairing.sendResult(

--- a/lib/apis/web3wallet/web3wallet.dart
+++ b/lib/apis/web3wallet/web3wallet.dart
@@ -4,6 +4,7 @@ import 'package:walletconnect_flutter_v2/apis/core/relay_client/websocket/i_http
 import 'package:walletconnect_flutter_v2/apis/core/store/generic_store.dart';
 import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sessions.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine_wallet.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
 import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
 
@@ -239,7 +240,7 @@ class Web3Wallet implements IWeb3Wallet {
   void registerRequestHandler({
     required String chainId,
     required String method,
-    dynamic Function(String, dynamic)? handler,
+    RequestHandler? handler,
   }) {
     try {
       return signEngine.registerRequestHandler(

--- a/test/sign_api/tests/sign_request_and_handler.dart
+++ b/test/sign_api/tests/sign_request_and_handler.dart
@@ -75,8 +75,9 @@ void signRequestAndHandler({
       expect(clientB.getPendingSessionRequests().length, 0);
 
       // Valid handler
-      Future<dynamic> Function(String, dynamic) requestHandler = (
+      RequestHandler requestHandler = (
         String topic,
+        String chainId,
         dynamic request,
       ) async {
         expect(topic, sessionTopic);
@@ -148,6 +149,7 @@ void signRequestAndHandler({
       // Valid handler that throws an error
       requestHandler = (
         String topic,
+        String chainId,
         dynamic request,
       ) async {
         if (request is String) {

--- a/test/sign_api/utils/sign_client_test_wrapper.dart
+++ b/test/sign_api/utils/sign_client_test_wrapper.dart
@@ -1,8 +1,9 @@
 import 'package:walletconnect_flutter_v2/apis/core/relay_client/websocket/http_client.dart';
 import 'package:walletconnect_flutter_v2/apis/core/relay_client/websocket/i_http_client.dart';
 import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sessions.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine_wallet.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
 import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
 
 class SignClientTestWrapper implements ISignEngine {
@@ -187,7 +188,7 @@ class SignClientTestWrapper implements ISignEngine {
   void registerRequestHandler({
     required String chainId,
     required String method,
-    void Function(String, dynamic)? handler,
+    RequestHandler? handler,
   }) {
     try {
       return client.registerRequestHandler(


### PR DESCRIPTION
# Description

Added chainId as a parameter in the registerRequestHandler method. This helps identify which chainId the dApp is currently using. 

Without this it is hard to tell which chain to use in the request since you can pass multiple chains to dApp (attaching a log of how session namespaces look when registering multiple chains):

```
{eip155: Namespace(accounts: [eip155:56:0xA0E86987Cc1e360B4BB191bcEf0548AD86Ed57A8, eip155:1:0xA0E86987Cc1e360B4BB191bcEf0548AD86Ed57A8], methods: [eth_sendTransaction, personal_sign], events: [chainChanged, accountsChanged])}
```

Resolves #258

## How Has This Been Tested?

Tested the changes on the example wallet app as well as my own app. Everything works as expected.