### PR TITLE
Fix Sign Engines's session request logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+- [Wallet] Fixed and issue where Sign Engine was not properly deciding between using a registered request handler or emitting an onSessionRequest event.
+
 ## 2.2.0
 
 - Added Smart Contract interactions to SignEngine

--- a/example/dapp/lib/utils/crypto/eip155.dart
+++ b/example/dapp/lib/utils/crypto/eip155.dart
@@ -66,7 +66,7 @@ class EIP155 {
           topic: topic,
           chainId: chainData.chainId,
           address: address,
-          data: testSignData,
+          message: testSignData,
         );
       case EIP155Methods.ethSign:
         return ethSign(
@@ -74,7 +74,7 @@ class EIP155 {
           topic: topic,
           chainId: chainData.chainId,
           address: address,
-          data: testSignData,
+          message: testSignData,
         );
       case EIP155Methods.ethSignTypedData:
         return ethSignTypedData(
@@ -159,14 +159,14 @@ class EIP155 {
     required String topic,
     required String chainId,
     required String address,
-    required String data,
+    required String message,
   }) async {
     return await web3App.request(
       topic: topic,
       chainId: chainId,
       request: SessionRequestParams(
         method: methods[EIP155Methods.personalSign]!,
-        params: [data, address],
+        params: [message, address],
       ),
     );
   }
@@ -176,14 +176,14 @@ class EIP155 {
     required String topic,
     required String chainId,
     required String address,
-    required String data,
+    required String message,
   }) async {
     return await web3App.request(
       topic: topic,
       chainId: chainId,
       request: SessionRequestParams(
         method: methods[EIP155Methods.ethSign]!,
-        params: [address, data],
+        params: [address, message],
       ),
     );
   }

--- a/example/dapp/lib/widgets/session_widget.dart
+++ b/example/dapp/lib/widgets/session_widget.dart
@@ -167,6 +167,8 @@ class SessionWidgetState extends State<SessionWidget> {
     final List<Widget> buttons = [];
     // Add Methods
     for (final String method in getChainMethods(chainMetadata.type)) {
+      final namespaces = widget.session.namespaces[chainMetadata.type.name];
+      final supported = namespaces?.methods.contains(method) ?? false;
       buttons.add(
         Container(
           width: double.infinity,
@@ -175,20 +177,24 @@ class SessionWidgetState extends State<SessionWidget> {
             vertical: StyleConstants.linear8,
           ),
           child: ElevatedButton(
-            onPressed: () async {
-              final future = EIP155.callMethod(
-                web3App: widget.web3App,
-                topic: widget.session.topic,
-                method: method.toEip155Method()!,
-                chainData: chainMetadata,
-                address: address.toLowerCase(),
-              );
-              MethodDialog.show(context, method, future);
-              _launchWallet();
-            },
+            onPressed: supported
+                ? () async {
+                    final future = EIP155.callMethod(
+                      web3App: widget.web3App,
+                      topic: widget.session.topic,
+                      method: method.toEip155Method()!,
+                      chainData: chainMetadata,
+                      address: address.toLowerCase(),
+                    );
+                    MethodDialog.show(context, method, future);
+                    _launchWallet();
+                  }
+                : null,
             style: ButtonStyle(
-              backgroundColor: MaterialStateProperty.all<Color>(
-                chainMetadata.color,
+              backgroundColor: MaterialStateProperty.resolveWith<Color>(
+                (states) => states.contains(MaterialState.disabled)
+                    ? Colors.grey
+                    : chainMetadata.color,
               ),
               shape: MaterialStateProperty.all<RoundedRectangleBorder>(
                 RoundedRectangleBorder(

--- a/example/wallet/lib/dependencies/chains/evm_service.dart
+++ b/example/wallet/lib/dependencies/chains/evm_service.dart
@@ -48,8 +48,7 @@ class EVMService {
     );
     ethClient = Web3Client(chainMetadata.rpc.first, http.Client());
 
-    const supportedEvents = EventsConstants.requiredEvents;
-    for (final event in supportedEvents) {
+    for (final event in EventsConstants.requiredEvents) {
       _web3Wallet.registerEventEmitter(
         chainId: chainSupported.chainId,
         event: event,
@@ -68,8 +67,8 @@ class EVMService {
   }
 
   void _onSessionRequest(SessionRequestEvent? args) async {
-    if (args != null && args.chainId == chainSupported.chainId) {
-      debugPrint('[$runtimeType] onSessionRequest $args');
+    if (args?.chainId == chainSupported.chainId) {
+      debugPrint('[$runtimeType] onSessionRequest ${args!}');
       final handler = sessionRequestHandlers[args.method];
       if (handler != null) {
         await handler(args.topic, args.params);
@@ -250,7 +249,7 @@ class EVMService {
     );
   }
 
-  Future<dynamic> ethSignTransaction(String topic, dynamic parameters) async {
+  Future<void> ethSignTransaction(String topic, dynamic parameters) async {
     debugPrint('[$runtimeType] ethSignTransaction request: $parameters');
     final pRequest = _web3Wallet.pendingRequests.getAll().last;
     final data = EthUtils.getTransactionFromParams(parameters);
@@ -303,7 +302,7 @@ class EVMService {
     );
   }
 
-  Future<dynamic> ethSendTransaction(String topic, dynamic parameters) async {
+  Future<void> ethSendTransaction(String topic, dynamic parameters) async {
     debugPrint('[$runtimeType] ethSendTransaction request: $parameters');
     final pRequest = _web3Wallet.pendingRequests.getAll().last;
     final data = EthUtils.getTransactionFromParams(parameters);

--- a/example/wallet/lib/dependencies/web3wallet_service.dart
+++ b/example/wallet/lib/dependencies/web3wallet_service.dart
@@ -167,6 +167,9 @@ class Web3WalletService extends IWeb3WalletService {
 
   void _onSessionProposal(SessionProposalEvent? args) async {
     if (args != null) {
+      final accounts = args.params.generatedNamespaces?['eip155']?.accounts;
+      final allChains = NamespaceUtils.getChainsFromAccounts(accounts ?? []);
+      debugPrint('[$runtimeType] _onSessionProposal chains: $allChains');
       final approved = await _bottomSheetHandler.queueBottomSheet(
         widget: WCRequestWidget(
           child: WCConnectionRequestWidget(

--- a/example/wallet/lib/utils/namespace_model_builder.dart
+++ b/example/wallet/lib/utils/namespace_model_builder.dart
@@ -11,25 +11,28 @@ class ConnectionWidgetBuilder {
   ) {
     final List<WCConnectionWidget> views = [];
     for (final key in generatedNamespaces.keys) {
-      Namespace ns = generatedNamespaces[key]!;
+      final namespaces = generatedNamespaces[key]!;
+      final chains = NamespaceUtils.getChainsFromAccounts(namespaces.accounts);
       final List<WCConnectionModel> models = [];
       // If the chains property is present, add the chain data to the models
       models.add(
         WCConnectionModel(
           title: StringConstants.chains,
-          elements: ns.accounts.map((acc) {
-            return NamespaceUtils.getChainFromAccount(acc);
-          }).toList(),
+          elements: chains,
         ),
       );
-      models.add(WCConnectionModel(
-        title: StringConstants.methods,
-        elements: ns.methods,
-      ));
-      models.add(WCConnectionModel(
-        title: StringConstants.events,
-        elements: ns.events,
-      ));
+      models.add(
+        WCConnectionModel(
+          title: StringConstants.methods,
+          elements: namespaces.methods,
+        ),
+      );
+      models.add(
+        WCConnectionModel(
+          title: StringConstants.events,
+          elements: namespaces.events,
+        ),
+      );
 
       views.add(
         WCConnectionWidget(
@@ -48,12 +51,12 @@ class ConnectionWidgetBuilder {
   ) {
     final List<WCConnectionWidget> views = [];
     for (final key in namespaces.keys) {
-      final Namespace ns = namespaces[key]!;
+      final ns = namespaces[key]!;
       final List<WCConnectionModel> models = [];
       // If the chains property is present, add the chain data to the models
       models.add(
         WCConnectionModel(
-          title: StringConstants.chains,
+          title: StringConstants.accounts,
           elements: ns.accounts,
         ),
       );

--- a/example/wallet/lib/utils/string_constants.dart
+++ b/example/wallet/lib/utils/string_constants.dart
@@ -28,6 +28,7 @@ class StringConstants {
 
   // Session Proposal
   static const String chains = 'Chains';
+  static const String accounts = 'Accounts';
   static const String methods = 'Methods';
   static const String events = 'Events';
 

--- a/lib/apis/core/relay_client/relay_client.dart
+++ b/lib/apis/core/relay_client/relay_client.dart
@@ -236,7 +236,7 @@ class RelayClient implements IRelayClient {
   Future<void> _createJsonRPCProvider() async {
     _connecting = true;
     _active = true;
-    var auth = await core.crypto.signJWT(core.relayUrl);
+    final auth = await core.crypto.signJWT(core.relayUrl);
     core.logger.t('Signed JWT: $auth');
     try {
       final url = WalletConnectUtils.formatRelayRpcUrl(

--- a/lib/apis/core/verify/verify.dart
+++ b/lib/apis/core/verify/verify.dart
@@ -62,6 +62,12 @@ class Verify implements IVerify {
       final error = 'Attestation response error: ${response.statusCode}';
       throw Exception(error);
     }
+    if (response.body.isEmpty) {
+      throw AttestationNotFound(
+        code: 404,
+        message: 'Attestion for this dapp could not be found',
+      );
+    }
     return AttestationResponse.fromJson(jsonDecode(response.body));
   }
 

--- a/lib/apis/sign_api/sign_engine.dart
+++ b/lib/apis/sign_api/sign_engine.dart
@@ -267,9 +267,9 @@ class SignEngine implements ISignEngine {
       peerPubKey,
     );
     // print('approve session topic: $sessionTopic');
-    final relay = Relay(
-      relayProtocol ?? 'irn',
-    );
+    final protocol =
+        relayProtocol ?? WalletConnectConstants.RELAYER_DEFAULT_PROTOCOL;
+    final relay = Relay(protocol);
 
     // Respond to the proposal
     await core.pairing.sendResult(
@@ -277,9 +277,7 @@ class SignEngine implements ISignEngine {
       proposal.pairingTopic,
       MethodConstants.WC_SESSION_PROPOSE,
       WcSessionProposeResponse(
-        relay: Relay(
-          relayProtocol ?? WalletConnectConstants.RELAYER_DEFAULT_PROTOCOL,
-        ),
+        relay: relay,
         responderPublicKey: selfPubKey,
       ),
     );
@@ -1273,62 +1271,44 @@ class SignEngine implements ISignEngine {
         sessionRequest,
       );
 
-      final String methodKey = _getRegisterKey(
+      final methodKey = _getRegisterKey(
         request.chainId,
         request.request.method,
       );
-      // print('method key: $methodKey');
-      if (_methodHandlers.containsKey(methodKey)) {
-        final handler = _methodHandlers[methodKey];
-        if (handler != null) {
-          try {
-            final result = await handler(
-              topic,
-              request.request.params,
-            );
-            await core.pairing.sendResult(
-              payload.id,
-              topic,
-              MethodConstants.WC_SESSION_REQUEST,
-              result,
-            );
-          } on WalletConnectError catch (e) {
-            await core.pairing.sendError(
-              payload.id,
-              topic,
-              payload.method,
-              JsonRpcError.fromJson(
-                e.toJson(),
-              ),
-            );
-          } on WalletConnectErrorSilent catch (_) {
-            // Do nothing on silent error
-          } catch (err) {
-            await core.pairing.sendError(
-              payload.id,
-              topic,
-              payload.method,
-              JsonRpcError.invalidParams(
-                err.toString(),
-              ),
-            );
-          }
-
+      final handler = _methodHandlers[methodKey];
+      // If a method handler has been set using registerRequestHandler we use it to process the request
+      if (handler != null) {
+        try {
+          await handler(topic, request.request.params);
+        } on WalletConnectError catch (e) {
+          await core.pairing.sendError(
+            payload.id,
+            topic,
+            payload.method,
+            JsonRpcError.fromJson(
+              e.toJson(),
+            ),
+          );
+          await _deletePendingRequest(payload.id);
+        } on WalletConnectErrorSilent catch (_) {
+          // Do nothing on silent error
+          await _deletePendingRequest(payload.id);
+        } catch (err) {
+          await core.pairing.sendError(
+            payload.id,
+            topic,
+            payload.method,
+            JsonRpcError.invalidParams(
+              err.toString(),
+            ),
+          );
           await _deletePendingRequest(payload.id);
         }
-
+      } else {
+        // Otherwise we send onSessionRequest event
         onSessionRequest.broadcast(
           SessionRequestEvent.fromSessionRequest(
             sessionRequest,
-          ),
-        );
-      } else {
-        await core.pairing.sendError(
-          payload.id,
-          topic,
-          payload.method,
-          JsonRpcError.methodNotFound(
-            'No handler found for chainId:method -> $methodKey',
           ),
         );
       }

--- a/lib/apis/sign_api/sign_engine.dart
+++ b/lib/apis/sign_api/sign_engine.dart
@@ -1278,7 +1278,8 @@ class SignEngine implements ISignEngine {
         request.request.method,
       );
 
-      // else, we send an onSessionRequest event
+      // We send onSessionRequest event on every session request,
+      // the developer can decide wether to use it or just register method handlers
       onSessionRequest.broadcast(
         SessionRequestEvent.fromSessionRequest(
           sessionRequest,
@@ -1286,8 +1287,8 @@ class SignEngine implements ISignEngine {
       );
 
       final methodHandler = _methodHandlers[methodKey];
+      // If a method handler has been set using registerRequestHandler we use it to process the request
       if (methodHandler != null) {
-        // If a method handler has been set using registerRequestHandler we use it to process the request
         try {
           final result = await methodHandler(topic, request.request.params);
           await core.pairing.sendResult(

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.2.0';
+const packageVersion = '2.2.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: walletconnect_flutter_v2
 description: This repository contains oficial implementation of WalletConnect v2 protocols for Flutter applications. The communications protocol for web3.
-version: 2.2.0
+version: 2.2.1
 repository: https://github.com/WalletConnect/WalletConnectFlutterV2
 
 environment:

--- a/test/auth_api/auth_client_test.dart
+++ b/test/auth_api/auth_client_test.dart
@@ -20,7 +20,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',

--- a/test/core_api/core_test.dart
+++ b/test/core_api/core_test.dart
@@ -11,7 +11,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',

--- a/test/core_api/pairing_store_test.dart
+++ b/test/core_api/pairing_store_test.dart
@@ -20,7 +20,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',

--- a/test/core_api/pairing_test.dart
+++ b/test/core_api/pairing_test.dart
@@ -20,7 +20,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',

--- a/test/core_api/relay_auth_test.dart
+++ b/test/core_api/relay_auth_test.dart
@@ -11,7 +11,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',

--- a/test/core_api/relay_client_test.dart
+++ b/test/core_api/relay_client_test.dart
@@ -15,7 +15,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',

--- a/test/sign_api/sign_client_test.dart
+++ b/test/sign_api/sign_client_test.dart
@@ -13,7 +13,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',

--- a/test/sign_api/sign_engine_test.dart
+++ b/test/sign_api/sign_engine_test.dart
@@ -12,7 +12,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',

--- a/test/sign_api/tests/sign_request_and_handler.dart
+++ b/test/sign_api/tests/sign_request_and_handler.dart
@@ -180,16 +180,6 @@ void signRequestAndHandler({
       );
 
       try {
-        // print('silent error');
-        // clientA.request(
-        //   topic: connectionInfo.session.topic,
-        //   chainId: TEST_ETHEREUM_CHAIN,
-        //   request: const SessionRequestParams(
-        //     method: TEST_METHOD_1,
-        //     params: 'silent',
-        //   ),
-        // );
-
         // print('user rejected sign');
         await clientA.request(
           topic: connectionInfo.session.topic,

--- a/test/sign_api/tests/sign_request_and_handler.dart
+++ b/test/sign_api/tests/sign_request_and_handler.dart
@@ -83,8 +83,14 @@ void signRequestAndHandler({
         // expect(request, TEST_MESSAGE_1);
         // print(clientB.getPendingSessionRequests());
         expect(clientB.getPendingSessionRequests().length, 1);
-
-        return request;
+        final pRequest = clientB.pendingRequests.getAll().last;
+        return await clientB.respondSessionRequest(
+          topic: sessionTopic,
+          response: JsonRpcResponse(
+            id: pRequest.id,
+            result: request,
+          ),
+        );
       };
       clientB.registerRequestHandler(
         chainId: TEST_ETHEREUM_CHAIN,
@@ -150,15 +156,22 @@ void signRequestAndHandler({
         String topic,
         dynamic request,
       ) async {
-        if (request is String) {
-          if (request == TEST_MESSAGE_2) {
-            throw Errors.getSdkError(Errors.USER_REJECTED_SIGN);
-          } else {
-            throw WalletConnectErrorSilent();
-          }
-        } else {
-          return request['try']!;
+        expect(topic, sessionTopic);
+        expect(clientB.getPendingSessionRequests().length, 1);
+        if (request == 'silent') {
+          throw WalletConnectErrorSilent();
         }
+        final pRequest = clientB.pendingRequests.getAll().last;
+        late dynamic error = (request is String)
+            ? Errors.getSdkError(Errors.USER_REJECTED_SIGN)
+            : JsonRpcError.invalidParams('swag');
+        return await clientB.respondSessionRequest(
+          topic: sessionTopic,
+          response: JsonRpcResponse(
+            id: pRequest.id,
+            error: JsonRpcError(code: error.code, message: error.message),
+          ),
+        );
       };
       clientB.registerRequestHandler(
         chainId: TEST_ETHEREUM_CHAIN,
@@ -168,14 +181,14 @@ void signRequestAndHandler({
 
       try {
         // print('silent error');
-        clientA.request(
-          topic: connectionInfo.session.topic,
-          chainId: TEST_ETHEREUM_CHAIN,
-          request: const SessionRequestParams(
-            method: TEST_METHOD_1,
-            params: 'silent',
-          ),
-        );
+        // clientA.request(
+        //   topic: connectionInfo.session.topic,
+        //   chainId: TEST_ETHEREUM_CHAIN,
+        //   request: const SessionRequestParams(
+        //     method: TEST_METHOD_1,
+        //     params: 'silent',
+        //   ),
+        // );
 
         // print('user rejected sign');
         await clientA.request(
@@ -200,8 +213,20 @@ void signRequestAndHandler({
         );
       }
 
+      Completer pendingRequestCompleter = Completer();
+      clientB.pendingRequests.onSync.subscribe((_) {
+        if (clientB.getPendingSessionRequests().isEmpty) {
+          pendingRequestCompleter.complete();
+        }
+      });
+      if (!pendingRequestCompleter.isCompleted) {
+        clientA.core.logger.i('waiting pendingRequestCompleter');
+        await pendingRequestCompleter.future;
+      }
+      clientB.pendingRequests.onSync.unsubscribeAll();
+
       try {
-        final _ = await clientA.request(
+        await clientA.request(
           topic: connectionInfo.session.topic,
           chainId: TEST_ETHEREUM_CHAIN,
           request: const SessionRequestParams(
@@ -218,31 +243,18 @@ void signRequestAndHandler({
         );
       }
 
-      Completer pendingRequestCompleter = Completer();
-      Completer sessionRequestCompleter = Completer();
+      pendingRequestCompleter = Completer();
       clientB.pendingRequests.onSync.subscribe((_) {
         if (clientB.getPendingSessionRequests().isEmpty) {
           pendingRequestCompleter.complete();
         }
       });
-      clientB.onSessionRequest.subscribe((args) {
-        sessionRequestCompleter.complete();
-        sessionRequestCompleter = Completer();
-      });
-
       if (!pendingRequestCompleter.isCompleted) {
         clientA.core.logger.i('waiting pendingRequestCompleter');
         await pendingRequestCompleter.future;
       }
-      if (!sessionRequestCompleter.isCompleted) {
-        clientA.core.logger.i('waiting sessionRequestComplete');
-        await sessionRequestCompleter.future;
-      }
       clientB.pendingRequests.onSync.unsubscribeAll();
-      clientB.onSessionRequest.unsubscribeAll();
-      expect(clientB.getPendingSessionRequests().length, 0);
 
-      /// Event driven, null handler ///
       clientB.registerRequestHandler(
         chainId: TEST_ETHEREUM_CHAIN,
         method: TEST_METHOD_1,
@@ -252,31 +264,31 @@ void signRequestAndHandler({
         method: TEST_METHOD_2,
       );
       clientB.onSessionRequest.subscribe((
-        SessionRequestEvent? request,
+        SessionRequestEvent? event,
       ) async {
-        expect(request != null, true);
-        expect(request!.topic, sessionTopic);
-        expect(request.params, TEST_MESSAGE_1);
+        expect(event != null, true);
+        expect(event!.topic, sessionTopic);
+        expect(event.params, TEST_MESSAGE_1);
 
-        if (request.method == TEST_METHOD_1) {
-          expect(clientB.pendingRequests.has(request.id.toString()), true);
+        if (event.method == TEST_METHOD_1) {
+          expect(clientB.pendingRequests.has(event.id.toString()), true);
           expect(clientB.getPendingSessionRequests().length, 1);
 
           await clientB.respondSessionRequest(
-            topic: request.topic,
+            topic: event.topic,
             response: JsonRpcResponse<Map<String, String>>(
-              id: request.id,
+              id: event.id,
               result: TEST_MESSAGE_1,
             ),
           );
 
-          expect(clientB.pendingRequests.has(request.id.toString()), false);
-        } else if (request.method == TEST_METHOD_2) {
+          expect(clientB.pendingRequests.has(event.id.toString()), false);
+        } else if (event.method == TEST_METHOD_2) {
           await clientB.respondSessionRequest(
-            topic: request.topic,
+            topic: event.topic,
             response: JsonRpcResponse(
-              id: request.id,
-              error: JsonRpcError.invalidParams(request.params.toString()),
+              id: event.id,
+              error: JsonRpcError.invalidParams(event.params.toString()),
             ),
           );
         }
@@ -316,23 +328,23 @@ void signRequestAndHandler({
       // Try an error
       clientB.onSessionRequest.unsubscribeAll();
       clientB.onSessionRequest.subscribe((
-        SessionRequestEvent? session,
+        SessionRequestEvent? event,
       ) async {
-        expect(session != null, true);
-        expect(session!.topic, sessionTopic);
-        expect(session.params, TEST_MESSAGE_1);
+        expect(event != null, true);
+        expect(event!.topic, sessionTopic);
+        expect(event.params, TEST_MESSAGE_1);
 
-        expect(clientB.pendingRequests.has(session.id.toString()), true);
+        expect(clientB.pendingRequests.has(event.id.toString()), true);
 
         await clientB.respondSessionRequest(
-          topic: session.topic,
+          topic: event.topic,
           response: JsonRpcResponse<String>(
-            id: session.id,
+            id: event.id,
             error: JsonRpcError.invalidParams('invalid'),
           ),
         );
 
-        expect(clientB.pendingRequests.has(session.id.toString()), false);
+        expect(clientB.pendingRequests.has(event.id.toString()), false);
       });
 
       try {

--- a/test/sign_api/web3wallet_sign_test.dart
+++ b/test/sign_api/web3wallet_sign_test.dart
@@ -10,7 +10,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',

--- a/test/web3wallet/web3wallet_test.dart
+++ b/test/web3wallet/web3wallet_test.dart
@@ -12,7 +12,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   PackageInfo.setMockInitialValues(
     appName: 'walletconnect_flutter_v2',
-    packageName: 'sdk.test',
+    packageName: 'com.walletconnect.flutterdapp',
     version: '1.0',
     buildNumber: '2',
     buildSignature: 'buildSignature',


### PR DESCRIPTION
# Description

There was a bad decision-making process inside Sign Engine in regards of session requests where a wallet could use methods handlers AND `onSessionRequest` events but not separately.

The data carried by both logics didn't change, method handler will still make use of `topic` and `parameters` and `onSessionRequest` event will still make use of `SessionRequestEvent` object which contains `id`, `topic`, `method`, `chainId` and `params` but by fixing the decision-making logic inside Sign Engine we now resolve this issue https://github.com/WalletConnect/WalletConnectFlutterV2/issues/258

### APPROVE SESSIONS:

#### BEFORE PR:

- Until now, most developers were relying on `generatedNamespaces` object inside of `SessionProposalEvent`'s params, which is a handy object that determines automatically which methods are supported based on which handlers are registered with `registerRequestHandler()`

#### AFTER PR:

- Now, `generatedNamespaces` is still a valid object to be used to approve a session but if the **wallet** developer wants to handle session requests using `onSessionRequest` events (without registering a handler) then they will need to pass to `approveSession()` a custom set of namespaces that would include those methods without a registered handler. (This is similar to any other SDK)

### HANDLING SESSION REQUESTS:

#### BEFORE PR:

- Until now, only by registering request handlers was possible to handle a session (method) request and only after handling it with the registered handler, only then, an `onSessionRequest` event was emitted (which was useless since the request was already being responded at that point).
- Furthermore, **and more importantly**, there was no way of handling the request with `onSessionRequest` since the `onSessionRequest`'s event was being emitted only if a request handler was registered before and if a request handler was not registered for a given method then that method was considered unsupported. **This is wrong!**

#### AFTER PR:

- Now, if a method handler is registered for a given method then that handler is going to be used to handle the request **WITHOUT** emitting an `onSessionRequest` event (which was anyway useless before, as mentioned above)
- Now, i**f no method handler is registered** for a given method, an `onSessionRequest` event will be emitted for that request and the request would have to be handled in the `onSessionRequest` subscription method. If there are no methods handlers registered then every request will emit an `onSessionRequest` event to be handled.

## How Has This Been Tested?

- Smoke and manual tests. 
- Fixed UT accordingly.

## Due Dilligence

* [ ] Breaking change
* [X] Requires a documentation update