### PR TITLE
Add access to approve session properties

### DIFF
--- a/lib/apis/sign_api/i_sign_client.dart
+++ b/lib/apis/sign_api/i_sign_client.dart
@@ -46,6 +46,7 @@ abstract class ISignClient {
   Future<ApproveResponse> approve({
     required int id,
     required Map<String, Namespace> namespaces,
+    Map<String, String>? sessionProperties,
     String? relayProtocol,
   });
   Future<void> reject({

--- a/lib/apis/sign_api/i_sign_engine_wallet.dart
+++ b/lib/apis/sign_api/i_sign_engine_wallet.dart
@@ -20,6 +20,7 @@ abstract class ISignEngineWallet extends ISignEngineCommon {
   Future<ApproveResponse> approveSession({
     required int id,
     required Map<String, Namespace> namespaces,
+    Map<String, String>? sessionProperties,
     String? relayProtocol,
   });
   Future<void> rejectSession({

--- a/lib/apis/sign_api/sign_client.dart
+++ b/lib/apis/sign_api/sign_client.dart
@@ -1,23 +1,23 @@
 import 'package:event/event.dart';
 import 'package:walletconnect_flutter_v2/apis/core/core.dart';
+import 'package:walletconnect_flutter_v2/apis/core/i_core.dart';
+import 'package:walletconnect_flutter_v2/apis/core/pairing/i_pairing_store.dart';
+import 'package:walletconnect_flutter_v2/apis/core/pairing/utils/pairing_models.dart';
+import 'package:walletconnect_flutter_v2/apis/core/relay_client/relay_client_models.dart';
 import 'package:walletconnect_flutter_v2/apis/core/store/generic_store.dart';
 import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
-import 'package:walletconnect_flutter_v2/apis/core/pairing/i_pairing_store.dart';
-import 'package:walletconnect_flutter_v2/apis/core/relay_client/relay_client_models.dart';
 import 'package:walletconnect_flutter_v2/apis/models/basic_models.dart';
 import 'package:walletconnect_flutter_v2/apis/models/json_rpc_response.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine.dart';
-import 'package:walletconnect_flutter_v2/apis/core/pairing/utils/pairing_models.dart';
-import 'package:walletconnect_flutter_v2/apis/core/i_core.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sessions.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_client.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/i_sign_engine.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/json_rpc_models.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/proposal_models.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_models.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_events.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/session_models.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_events.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/models/sign_client_models.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/sessions.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
 import 'package:walletconnect_flutter_v2/apis/utils/constants.dart';
 import 'package:walletconnect_flutter_v2/apis/utils/log_level.dart';
 import 'package:web3dart/web3dart.dart';
@@ -174,12 +174,14 @@ class SignClient implements ISignClient {
   Future<ApproveResponse> approve({
     required int id,
     required Map<String, Namespace> namespaces,
+    Map<String, String>? sessionProperties,
     String? relayProtocol,
   }) async {
     try {
       return await engine.approveSession(
         id: id,
         namespaces: namespaces,
+        sessionProperties: sessionProperties,
         relayProtocol: relayProtocol,
       );
     } catch (e) {

--- a/lib/apis/sign_api/sign_engine.dart
+++ b/lib/apis/sign_api/sign_engine.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 
+import 'package:http/http.dart' as http;
 import 'package:walletconnect_flutter_v2/apis/core/pairing/utils/json_rpc_utils.dart';
 import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
 import 'package:walletconnect_flutter_v2/apis/core/verify/models/verify_context.dart';
@@ -312,6 +312,7 @@ class SignEngine implements ISignEngine {
         metadata: metadata,
       ),
       peer: proposal.proposer,
+      sessionProperties: sessionProperties,
     );
 
     // print('session connect');

--- a/lib/apis/sign_api/sign_engine.dart
+++ b/lib/apis/sign_api/sign_engine.dart
@@ -312,7 +312,7 @@ class SignEngine implements ISignEngine {
         metadata: metadata,
       ),
       peer: proposal.proposer,
-      sessionProperties: sessionProperties,
+      sessionProperties: proposal.sessionProperties,
     );
 
     // print('session connect');

--- a/lib/apis/web3wallet/web3wallet.dart
+++ b/lib/apis/web3wallet/web3wallet.dart
@@ -180,12 +180,14 @@ class Web3Wallet implements IWeb3Wallet {
   Future<ApproveResponse> approveSession({
     required int id,
     required Map<String, Namespace> namespaces,
+    Map<String, String>? sessionProperties,
     String? relayProtocol,
   }) async {
     try {
       return await signEngine.approveSession(
         id: id,
         namespaces: namespaces,
+        sessionProperties: sessionProperties,
         relayProtocol: relayProtocol,
       );
     } catch (e) {

--- a/test/sign_api/utils/sign_client_test_wrapper.dart
+++ b/test/sign_api/utils/sign_client_test_wrapper.dart
@@ -1,8 +1,8 @@
 import 'package:walletconnect_flutter_v2/apis/core/relay_client/websocket/http_client.dart';
 import 'package:walletconnect_flutter_v2/apis/core/relay_client/websocket/i_http_client.dart';
 import 'package:walletconnect_flutter_v2/apis/core/store/i_generic_store.dart';
-import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/i_sessions.dart';
+import 'package:walletconnect_flutter_v2/apis/sign_api/sign_engine.dart';
 import 'package:walletconnect_flutter_v2/walletconnect_flutter_v2.dart';
 
 class SignClientTestWrapper implements ISignEngine {
@@ -128,6 +128,7 @@ class SignClientTestWrapper implements ISignEngine {
   Future<ApproveResponse> approveSession({
     required int id,
     required Map<String, Namespace> namespaces,
+    Map<String, String>? sessionProperties,
     String? relayProtocol,
   }) async {
     try {


### PR DESCRIPTION
# Description
Allows full access to `SignEngine.approveSession` (specifically `sessionProperties`) params from interfaces.

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # (issue)

## How Has This Been Tested?
Smoke Test
<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update