### PR TITLE
Wallet sample app does not know how to accept contract methods such as swap

### DIFF
--- a/lib/apis/utils/extensions.dart
+++ b/lib/apis/utils/extensions.dart
@@ -36,12 +36,16 @@ extension TransactionExtension2 on Map<String, dynamic> {
           (this['maxPriorityFeePerGas'] as String?).toEthereAmount(),
       maxGas: (this['maxGas'] as String?).toIntFromHex(),
       nonce: (this['nonce'] as String?).toInt(),
-      data: (this['data'] != null && this['data'] != '0x')
-          ? Uint8List.fromList(hex.decode(this['data']!.startsWith('0x')
-              ? this['data']!.substring(2)
-              : this['data']!))
-          : null,
+      data: _parseTransactionData(this['data']),
     );
+  }
+
+  Uint8List? _parseTransactionData(dynamic data) {
+    if (data != null && data != '0x') {
+      return Uint8List.fromList(hex.decode(
+          data.startsWith('0x') ? data.substring(2) : data));
+    }
+    return null;
   }
 }
 

--- a/lib/apis/utils/extensions.dart
+++ b/lib/apis/utils/extensions.dart
@@ -39,14 +39,16 @@ extension TransactionExtension2 on Map<String, dynamic> {
       data: _parseTransactionData(this['data']),
     );
   }
+}
 
-  Uint8List? _parseTransactionData(dynamic data) {
-    if (data != null && data != '0x') {
-      return Uint8List.fromList(hex.decode(
-          data.startsWith('0x') ? data.substring(2) : data));
+Uint8List? _parseTransactionData(dynamic data) {
+  if (data != null && data != '0x') {
+    if (data.startsWith('0x')) {
+      return Uint8List.fromList(hex.decode(data.substring(2)));
     }
-    return null;
+    return Uint8List.fromList(hex.decode(data));
   }
+  return null;
 }
 
 extension EtheraAmountExtension on String? {

--- a/lib/apis/utils/extensions.dart
+++ b/lib/apis/utils/extensions.dart
@@ -37,7 +37,9 @@ extension TransactionExtension2 on Map<String, dynamic> {
       maxGas: (this['maxGas'] as String?).toIntFromHex(),
       nonce: (this['nonce'] as String?).toInt(),
       data: (this['data'] != null && this['data'] != '0x')
-          ? Uint8List.fromList(hex.decode(this['data']!))
+          ? Uint8List.fromList(hex.decode(this['data']!.startsWith('0x')
+              ? this['data']!.substring(2)
+              : this['data']!))
           : null,
     );
   }


### PR DESCRIPTION
# Description


Sample app wallet is not able to accept contract methods out of the box, for example it can be swap or approval methods. All this is due to incorrect parsing of the data parameter in the Transaction class. 

The thing is that in the source code data tries to be parsed using the Uint8List.fromList method, but it does not take into account that data can start with "0x", because of this an error occurs.

Before:
```
data: (this['data'] != null && this['data'] != '0x')
          ? Uint8List.fromList(hex.decode(this['data']!))
          : null,
```

After:
```
data: (this['data'] != null && this['data'] != '0x')
          ? Uint8List.fromList(hex.decode(this['data']!.startsWith('0x')
              ? this['data']!.substring(2)
              : this['data']!))
          : null,
```
## How Has This Been Tested?
This has been tested on several dapps, for example: 
1inch, uniswap.

No swap or approval was possible before the code was modified.

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update