### PR TITLE
Chore/one click auth fallback mecanism

### DIFF
--- a/example/dapp/lib/main.dart
+++ b/example/dapp/lib/main.dart
@@ -57,11 +57,9 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> initialize() async {
-    // try {
-    debugPrint('Project ID: ${DartDefines.projectId}');
     _web3App = await Web3App.createInstance(
       projectId: DartDefines.projectId,
-      logLevel: LogLevel.info,
+      logLevel: LogLevel.error,
       metadata: const PairingMetadata(
         name: 'Sample dApp Flutter',
         description: 'WalletConnect\'s sample dapp with Flutter',
@@ -80,7 +78,6 @@ class _MyHomePageState extends State<MyHomePage> {
     for (final ChainMetadata chain in ChainData.allChains) {
       // Loop through the events for that chain
       for (final event in getChainEvents(chain.type)) {
-        debugPrint('registerEventHandler $event for chain ${chain.chainId}');
         _web3App!.registerEventHandler(
           chainId: chain.chainId,
           event: event,
@@ -127,9 +124,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
       _initializing = false;
     });
-    // } on WalletConnectError catch (e) {
-    //   print(e.message);
-    // }
   }
 
   void _setState(dynamic args) => setState(() {});
@@ -240,7 +234,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   void _onSessionPing(SessionPing? args) {
-    debugPrint('[$runtimeType] _onSessionPing $args');
+    debugPrint('[SampleDapp] _onSessionPing $args');
     showDialog(
       context: context,
       builder: (BuildContext context) {
@@ -253,7 +247,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   void _onSessionEvent(SessionEvent? args) {
-    debugPrint('[$runtimeType] _onSessionEvent $args');
+    debugPrint('[SampleDapp] _onSessionEvent $args');
     showDialog(
       context: context,
       builder: (BuildContext context) {
@@ -267,7 +261,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   void _onSessionUpdate(SessionUpdate? args) {
-    debugPrint('[$runtimeType] _onSessionUpdate $args');
+    debugPrint('[SampleDapp] _onSessionUpdate $args');
   }
 
   void _onRelayMessage(MessageEvent? args) async {
@@ -278,9 +272,9 @@ class _MyHomePageState extends State<MyHomePage> {
           args.message,
         );
         final data = jsonDecode(payloadString ?? '{}') as Map<String, dynamic>;
-        debugPrint('[$runtimeType] _onRelayMessage data $data');
+        debugPrint('[SampleDapp] _onRelayMessage data $data');
       } catch (e) {
-        debugPrint('[$runtimeType] _onRelayMessage error $e');
+        debugPrint('[SampleDapp] _onRelayMessage error $e');
       }
     }
   }

--- a/example/dapp/lib/pages/connect_page.dart
+++ b/example/dapp/lib/pages/connect_page.dart
@@ -64,7 +64,7 @@ class ConnectPageState extends State<ConnectPage> {
       }
       _updateNamespaces();
 
-      debugPrint('$optionalNamespaces');
+      debugPrint('[SampleDapp] ${jsonEncode(optionalNamespaces)}');
     });
   }
 
@@ -285,7 +285,7 @@ class ConnectPageState extends State<ConnectPage> {
     Function(String message)? showToast,
     VoidCallback? closeModal,
   }) async {
-    debugPrint('Creating connection and session');
+    debugPrint('[SampleDapp] Creating connection and session');
     // It is currently safer to send chains approvals on optionalNamespaces
     // but depending on Wallet implementation you may need to send some (for innstance eip155:1) as required
     final connectResponse = await widget.web3App.connect(
@@ -323,7 +323,7 @@ class ConnectPageState extends State<ConnectPage> {
       _showQrCode(connectResponse.uri.toString());
     }
 
-    debugPrint('Awaiting session proposal settlement');
+    debugPrint('[SampleDapp] Awaiting session proposal settlement');
     final _ = await connectResponse.session.future;
 
     showToast?.call(StringConstants.connectionEstablished);
@@ -332,7 +332,7 @@ class ConnectPageState extends State<ConnectPage> {
 
   Future<void> _showQrCode(String uri) async {
     // Show the QR code
-    debugPrint('Showing QR Code: $uri');
+    debugPrint('[SampleDapp] Showing QR Code: $uri');
     _shouldDismissQrCode = true;
     if (kIsWeb) {
       await showDialog(
@@ -401,7 +401,7 @@ class ConnectPageState extends State<ConnectPage> {
         );
       },
     );
-    if (!shouldAuth) return;
+    if (shouldAuth != true) return;
 
     try {
       final pairingTopic = event?.session.pairingTopic;

--- a/example/dapp/lib/pages/pairings_page.dart
+++ b/example/dapp/lib/pages/pairings_page.dart
@@ -75,7 +75,7 @@ class PairingsPageState extends State<PairingsPage> {
                             );
                             Navigator.of(context).pop();
                           } catch (e) {
-                            debugPrint(e.toString());
+                            debugPrint('[SampleDapp] ${e.toString()}');
                           }
                         },
                       ),

--- a/example/dapp/lib/utils/crypto/helpers.dart
+++ b/example/dapp/lib/utils/crypto/helpers.dart
@@ -12,7 +12,7 @@ String getChainName(String chain) {
         .first
         .name;
   } catch (e) {
-    debugPrint('Invalid chain');
+    debugPrint('[SampleDapp] Invalid chain');
   }
   return 'Unknown';
 }
@@ -23,7 +23,7 @@ ChainMetadata getChainMetadataFromChain(String chain) {
         .where((element) => element.chainId == chain)
         .first;
   } catch (e) {
-    debugPrint('Invalid chain');
+    debugPrint('[SampleDapp] Invalid chain');
   }
   return ChainData.eip155Chains[0];
 }

--- a/example/dapp/lib/widgets/auth_item.dart
+++ b/example/dapp/lib/widgets/auth_item.dart
@@ -26,9 +26,8 @@ class AuthItem extends StatelessWidget {
               auth.p.domain,
               style: StyleConstants.paragraph,
             ),
-            Text(
-              auth.p.iss,
-            ),
+            Text(auth.p.iss),
+            Text('iat: ${auth.p.iat}'),
           ],
         ),
       ),

--- a/example/wallet/lib/dependencies/web3wallet_service.dart
+++ b/example/wallet/lib/dependencies/web3wallet_service.dart
@@ -56,14 +56,14 @@ class Web3WalletService extends IWeb3WalletService {
       for (final chainId in chainKey.chains) {
         if (chainId.startsWith('kadena')) {
           final account = '$chainId:k**${chainKey.address}';
-          debugPrint('[$runtimeType] registerAccount $account');
+          debugPrint('[SampleWallet] registerAccount $account');
           _web3Wallet!.registerAccount(
             chainId: chainId,
             accountAddress: 'k**${chainKey.address}',
           );
         } else {
           final account = '$chainId:${chainKey.address}';
-          debugPrint('[$runtimeType] registerAccount $account');
+          debugPrint('[SampleWallet] registerAccount $account');
           _web3Wallet!.registerAccount(
             chainId: chainId,
             accountAddress: chainKey.address,
@@ -73,7 +73,7 @@ class Web3WalletService extends IWeb3WalletService {
     }
 
     // Setup our listeners
-    debugPrint('[WALLET] [$runtimeType] create');
+    debugPrint('[SampleWallet] create');
     _web3Wallet!.core.pairing.onPairingInvalid.subscribe(_onPairingInvalid);
     _web3Wallet!.core.pairing.onPairingCreate.subscribe(_onPairingCreate);
     _web3Wallet!.onSessionProposal.subscribe(_onSessionProposal);
@@ -91,12 +91,11 @@ class Web3WalletService extends IWeb3WalletService {
   @override
   Future<void> init() async {
     // Await the initialization of the web3wallet
-    debugPrint('[$runtimeType] [WALLET] init');
     await _web3Wallet!.init();
   }
 
   void _logListener(LogEvent event) {
-    debugPrint('[WALLET] ${event.level.name}: ${event.message}');
+    debugPrint('[SampleWallet] ${event.level.name}: ${event.message}');
     if (event.level == Level.error) {
       // TODO send to mixpanel
     }
@@ -104,7 +103,6 @@ class Web3WalletService extends IWeb3WalletService {
 
   @override
   FutureOr onDispose() {
-    debugPrint('[$runtimeType] [WALLET] dispose');
     _web3Wallet!.core.removeLogListener(_logListener);
     _web3Wallet!.core.pairing.onPairingInvalid.unsubscribe(_onPairingInvalid);
     _web3Wallet!.core.pairing.onPairingCreate.unsubscribe(_onPairingCreate);
@@ -126,7 +124,7 @@ class Web3WalletService extends IWeb3WalletService {
   void _onRelayClientMessage(MessageEvent? event) async {
     if (event != null) {
       final jsonObject = await EthUtils.decodeMessageEvent(event);
-      debugPrint('[$runtimeType] [WALLET] _onRelayClientMessage $jsonObject');
+      debugPrint('[SampleWallet] _onRelayClientMessage $jsonObject');
       if (jsonObject is JsonRpcRequest) {
         if (jsonObject.method == 'wc_sessionPropose' ||
             jsonObject.method == 'wc_sessionRequest') {
@@ -150,7 +148,7 @@ class Web3WalletService extends IWeb3WalletService {
 
   void _onSessionProposal(SessionProposalEvent? args) async {
     if (args != null) {
-      log('[$runtimeType] [WALLET] _onSessionProposal ${jsonEncode(args.params)}');
+      log('[SampleWallet] _onSessionProposal ${jsonEncode(args.params)}');
       final approved = await _bottomSheetHandler.queueBottomSheet(
         widget: WCRequestWidget(
           child: WCConnectionRequestWidget(
@@ -191,7 +189,7 @@ class Web3WalletService extends IWeb3WalletService {
   }
 
   void _onSessionProposalError(SessionProposalErrorEvent? args) async {
-    debugPrint('[$runtimeType] [WALLET] _onSessionProposalError $args');
+    log('[SampleWallet] _onSessionProposalError $args');
     DeepLinkHandler.waiting.value = false;
     if (args != null) {
       String errorMessage = args.error.message;
@@ -230,26 +228,27 @@ class Web3WalletService extends IWeb3WalletService {
 
   void _onSessionConnect(SessionConnect? args) {
     if (args != null) {
-      log('[$runtimeType] [WALLET] _onSessionConnect ${jsonEncode(args.session)}');
+      log('[SampleWallet] _onSessionConnect ${jsonEncode(args.session)}');
       final scheme = args.session.peer.metadata.redirect?.native ?? '';
       DeepLinkHandler.goTo(scheme);
     }
   }
 
   void _onRelayClientError(ErrorEvent? args) {
-    debugPrint('[$runtimeType] [WALLET] _onRelayClientError ${args?.error}');
+    debugPrint(
+        '[$runtimeType] [SampleWallet] _onRelayClientError ${args?.error}');
   }
 
   void _onPairingInvalid(PairingInvalidEvent? args) {
-    debugPrint('[$runtimeType] [WALLET] _onPairingInvalid $args');
+    debugPrint('[$runtimeType] [SampleWallet] _onPairingInvalid $args');
   }
 
   void _onPairingCreate(PairingEvent? args) {
-    debugPrint('[$runtimeType] [WALLET] _onPairingCreate $args');
+    debugPrint('[$runtimeType] [SampleWallet] _onPairingCreate $args');
   }
 
   Future<void> _onAuthRequest(AuthRequest? args) async {
-    debugPrint('[$runtimeType] [WALLET] _onAuthRequest $args');
+    log('[SampleWallet] _onAuthRequest $args');
     if (args != null) {
       final chainKeys = GetIt.I<IKeyService>().getKeysForChain('eip155:1');
       // Create the message to be signed

--- a/lib/apis/core/pairing/pairing.dart
+++ b/lib/apis/core/pairing/pairing.dart
@@ -121,6 +121,7 @@ class Pairing implements IPairing {
       symKey: symKey,
       relay: relay,
       methods: methods,
+      expiry: expiry,
     );
 
     onPairingCreate.broadcast(

--- a/lib/apis/sign_api/i_sign_client.dart
+++ b/lib/apis/sign_api/i_sign_client.dart
@@ -41,7 +41,7 @@ abstract class ISignClient {
   // FORMER AUTH ENGINE PROPERTY
   abstract final Event<AuthResponse> onAuthResponse;
   // NEW 1-CA PROPERTY
-  abstract final Event<OCAResponse> onOCAResponse;
+  abstract final Event<OCAuthResponse> onOCAuthResponse;
 
   Future<void> init();
   Future<ConnectResponse> connect({
@@ -166,7 +166,7 @@ abstract class ISignClient {
     WalletConnectError? error,
   });
 
-  // FORMER AUTH ENGINE METHOD DAPP
+  // FORMER AUTH ENGINE METHOD WALLET
   // query all pending requests
   Map<int, PendingAuthRequest> getPendingAuthRequests();
 

--- a/lib/apis/sign_api/i_sign_engine_app.dart
+++ b/lib/apis/sign_api/i_sign_engine_app.dart
@@ -8,7 +8,7 @@ abstract class ISignEngineApp extends ISignEngineCommon {
   // FORMER AUTH ENGINE PROPERTY
   abstract final Event<AuthResponse> onAuthResponse;
   // NEW 1-CA PROPERTY
-  abstract final Event<OCAResponse> onOCAResponse;
+  abstract final Event<OCAuthResponse> onOCAuthResponse;
 
   Future<ConnectResponse> connect({
     Map<String, RequiredNamespace>? requiredNamespaces,

--- a/lib/apis/sign_api/models/auth/auth_client_models.dart
+++ b/lib/apis/sign_api/models/auth/auth_client_models.dart
@@ -129,30 +129,30 @@ class PendingAuthRequest with _$PendingAuthRequest {
       _$PendingAuthRequestFromJson(json);
 }
 
-class AuthRequestCompleter {
-  final int id;
-  final String pairingTopic;
-  final String responseTopic;
-  final PendingAuthRequest request;
-  final Completer<Cacao> completer;
+// class AuthRequestCompleter {
+//   final int id;
+//   final String pairingTopic;
+//   final String responseTopic;
+//   final PendingAuthRequest request;
+//   final Completer<Cacao> completer;
 
-  AuthRequestCompleter({
-    required this.id,
-    required this.pairingTopic,
-    required this.responseTopic,
-    required this.request,
-    required this.completer,
-  });
-}
+//   AuthRequestCompleter({
+//     required this.id,
+//     required this.pairingTopic,
+//     required this.responseTopic,
+//     required this.request,
+//     required this.completer,
+//   });
+// }
 
-class RespondParams {
-  final int id;
-  final CacaoSignature? signature;
-  final WalletConnectError? error;
+// class RespondParams {
+//   final int id;
+//   final CacaoSignature? signature;
+//   final WalletConnectError? error;
 
-  RespondParams({
-    required this.id,
-    this.signature,
-    this.error,
-  });
-}
+//   RespondParams({
+//     required this.id,
+//     this.signature,
+//     this.error,
+//   });
+// }

--- a/lib/apis/sign_api/models/auth/one_click_auth_events.dart
+++ b/lib/apis/sign_api/models/auth/one_click_auth_events.dart
@@ -6,11 +6,11 @@ import 'package:walletconnect_flutter_v2/apis/models/json_rpc_error.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/auth/auth_common_models.dart';
 import 'package:walletconnect_flutter_v2/apis/sign_api/models/session_models.dart';
 
-class OCARequest extends EventArgs {
+class OCAuthRequest extends EventArgs {
   // TODO to be implemented for wallet usage
 }
 
-class OCAResponse extends EventArgs {
+class OCAuthResponse extends EventArgs {
   final int id;
   final String topic;
   final List<Cacao>? auths;
@@ -18,7 +18,7 @@ class OCAResponse extends EventArgs {
   final WalletConnectError? error;
   final JsonRpcError? jsonRpcError;
 
-  OCAResponse({
+  OCAuthResponse({
     required this.id,
     required this.topic,
     this.auths,

--- a/lib/apis/sign_api/models/auth/one_click_auth_models.dart
+++ b/lib/apis/sign_api/models/auth/one_click_auth_models.dart
@@ -8,10 +8,11 @@ import 'package:walletconnect_flutter_v2/apis/sign_api/models/auth/one_click_aut
 part 'one_click_auth_models.g.dart';
 part 'one_click_auth_models.freezed.dart';
 
+// TODO this should be under sign_client_models.dart probably
 class OCARequestResponse {
   final int id;
   final String pairingTopic;
-  final Completer<OCAResponse> completer;
+  final Completer<OCAuthResponse> completer;
   final Uri? uri;
 
   OCARequestResponse({

--- a/lib/apis/sign_api/sign_client.dart
+++ b/lib/apis/sign_api/sign_client.dart
@@ -506,7 +506,7 @@ class SignClient implements ISignClient {
 
   // NEW 1-CLICK AUTH METHOD
   @override
-  Event<OCAResponse> get onOCAResponse => engine.onOCAResponse;
+  Event<OCAuthResponse> get onOCAuthResponse => engine.onOCAuthResponse;
 
   @override
   Future<AuthRequestResponse> requestAuth({

--- a/lib/apis/sign_api/sign_client.dart
+++ b/lib/apis/sign_api/sign_client.dart
@@ -512,9 +512,7 @@ class SignClient implements ISignClient {
   Future<AuthRequestResponse> requestAuth({
     required AuthRequestParams params,
     String? pairingTopic,
-    List<List<String>>? methods = const [
-      [MethodConstants.WC_AUTH_REQUEST],
-    ],
+    List<List<String>>? methods = SignEngine.DEFAULT_METHODS_AUTH,
   }) {
     try {
       return engine.requestAuth(
@@ -533,7 +531,7 @@ class SignClient implements ISignClient {
     required OCARequestParams params,
     String? pairingTopic,
     List<List<String>>? methods = const [
-      [MethodConstants.WC_SESSION_AUTHENTICATE],
+      [MethodConstants.WC_SESSION_AUTHENTICATE]
     ],
   }) {
     try {

--- a/lib/apis/sign_api/sign_engine.dart
+++ b/lib/apis/sign_api/sign_engine.dart
@@ -85,7 +85,7 @@ class SignEngine implements ISignEngine {
 
   // NEW 1-CA METHOD
   @override
-  final Event<OCAResponse> onOCAResponse = Event<OCAResponse>();
+  final Event<OCAuthResponse> onOCAuthResponse = Event<OCAuthResponse>();
 
   // FORMER AUTH ENGINE PROPERTY (apparently not used befor and not used now)
   // List<AuthRequestCompleter> pendingAuthRequests = [];
@@ -2198,7 +2198,7 @@ class SignEngine implements ISignEngine {
     // ------------------------------------------------------- //
 
     // Send One-Click Auth request
-    Completer<OCAResponse> completer = Completer();
+    Completer<OCAuthResponse> completer = Completer();
     _requestOCAResponseHandler(
       id: id,
       publicKey: publicKey,
@@ -2242,7 +2242,7 @@ class SignEngine implements ISignEngine {
     required String responseTopic,
     required int expiry,
     required WcOCARequestParams request,
-    required Completer<OCAResponse> completer,
+    required Completer<OCAuthResponse> completer,
   }) async {
     //
     late WcOCARequestResult result;
@@ -2256,7 +2256,7 @@ class SignEngine implements ISignEngine {
       );
       result = WcOCARequestResult.fromJson(response);
     } catch (error) {
-      final response = OCAResponse(
+      final response = OCAuthResponse(
         id: id,
         topic: responseTopic,
         jsonRpcError: (error is JsonRpcError) ? error : null,
@@ -2267,7 +2267,7 @@ class SignEngine implements ISignEngine {
               )
             : null,
       );
-      onOCAResponse.broadcast(response);
+      onOCAuthResponse.broadcast(response);
       completer.complete(response);
       return;
     }
@@ -2323,7 +2323,7 @@ class SignEngine implements ISignEngine {
         }
       }
     } on WalletConnectError catch (e) {
-      final resp = OCAResponse(
+      final resp = OCAuthResponse(
         id: id,
         topic: responseTopic,
         error: WalletConnectError(
@@ -2331,7 +2331,7 @@ class SignEngine implements ISignEngine {
           message: e.message,
         ),
       );
-      onOCAResponse.broadcast(resp);
+      onOCAuthResponse.broadcast(resp);
       completer.complete(resp);
       return;
     }
@@ -2369,13 +2369,13 @@ class SignEngine implements ISignEngine {
       session = sessions.get(sessionTopic);
     }
 
-    final resp = OCAResponse(
+    final resp = OCAuthResponse(
       id: id,
       topic: responseTopic,
       auths: cacaos,
       session: session,
     );
-    onOCAResponse.broadcast(resp);
+    onOCAuthResponse.broadcast(resp);
     completer.complete(resp);
   }
 

--- a/lib/apis/sign_api/sign_engine.dart
+++ b/lib/apis/sign_api/sign_engine.dart
@@ -21,6 +21,12 @@ class SignEngine implements ISignEngine {
     ],
   ];
 
+  static const List<List<String>> DEFAULT_METHODS_AUTH = [
+    [
+      MethodConstants.WC_AUTH_REQUEST,
+    ]
+  ];
+
   bool _initialized = false;
 
   @override
@@ -232,13 +238,13 @@ class SignEngine implements ISignEngine {
     // print("sending proposal for $topic");
     // print('connectResponseHandler requestId: $requestId');
     try {
-      final Map<String, dynamic> resp = await core.pairing.sendRequest(
+      final Map<String, dynamic> response = await core.pairing.sendRequest(
         topic,
         MethodConstants.WC_SESSION_PROPOSE,
         request,
         id: requestId,
       );
-      final String peerPublicKey = resp['responderPublicKey'];
+      final String peerPublicKey = response['responderPublicKey'];
 
       final ProposalData proposal = proposals.get(
         requestId.toString(),
@@ -968,11 +974,11 @@ class SignEngine implements ISignEngine {
       type: ProtocolType.auth,
     );
     // TODO on following PR to be used by Wallet
-    // core.pairing.register(
-    //   method: MethodConstants.WC_SESSION_AUTHENTICATE,
-    //   function: _onOCARequest,
-    //   type: ProtocolType.auth,
-    // );
+    core.pairing.register(
+      method: MethodConstants.WC_SESSION_AUTHENTICATE,
+      function: _onOCARequest,
+      type: ProtocolType.auth,
+    );
   }
 
   Future<void> _onSessionProposeRequest(
@@ -1914,9 +1920,7 @@ class SignEngine implements ISignEngine {
   Future<AuthRequestResponse> requestAuth({
     required AuthRequestParams params,
     String? pairingTopic,
-    List<List<String>>? methods = const [
-      [MethodConstants.WC_AUTH_REQUEST],
-    ],
+    List<List<String>>? methods = DEFAULT_METHODS_AUTH,
   }) async {
     _checkInitialized();
 
@@ -2073,7 +2077,7 @@ class SignEngine implements ISignEngine {
     required OCARequestParams params,
     String? pairingTopic,
     List<List<String>>? methods = const [
-      [MethodConstants.WC_SESSION_AUTHENTICATE],
+      [MethodConstants.WC_SESSION_AUTHENTICATE]
     ],
   }) async {
     _checkInitialized();
@@ -2094,7 +2098,6 @@ class SignEngine implements ISignEngine {
       pTopic = pairing.topic;
       connectionUri = pairing.uri;
     } else {
-      // TODO this doesn't look correct
       core.pairing.isValidPairingTopic(topic: pTopic);
     }
 
@@ -2108,9 +2111,6 @@ class SignEngine implements ISignEngine {
       ),
       pairingTopics.set(responseTopic, pTopic),
     ]);
-
-    // Subscribe to the responseTopic because we expect the response to use this topic
-    await core.relayClient.subscribe(topic: responseTopic);
 
     if (requestMethods.isNotEmpty) {
       final namespace = NamespaceUtils.getNamespaceFromChain(chains.first);
@@ -2129,6 +2129,12 @@ class SignEngine implements ISignEngine {
       }
       resources.add(recap);
     }
+
+    // Subscribe to the responseTopic because we expect the response to use this topic
+    await core.relayClient.subscribe(topic: responseTopic);
+
+    final id = JsonRpcUtils.payloadId();
+    final proposalId = JsonRpcUtils.payloadId();
 
     // Ensure the expiry is greater than the minimum required for the request - currently 1h
     final method = MethodConstants.WC_SESSION_AUTHENTICATE;
@@ -2149,27 +2155,6 @@ class SignEngine implements ISignEngine {
       expiryTimestamp: expiryTimestamp.millisecondsSinceEpoch,
     );
 
-    // TODO fallback to session proposal to be implemented in following PR
-    // const namespaces = {
-    //   eip155: {
-    //     chains,
-    //     // request `personal_sign` method by default to allow for fallback siwe
-    //     methods: [...new Set(["personal_sign", ...methods])],
-    //     events: ["chainChanged", "accountsChanged"],
-    //   },
-    // };
-
-    // const proposal = {
-    //   requiredNamespaces: {},
-    //   optionalNamespaces: namespaces,
-    //   relays: [{ protocol: "irn" }],
-    //   proposer: {
-    //     publicKey,
-    //     metadata: this.client.metadata,
-    //   },
-    //   expiryTimestamp: calcExpiry(ENGINE_RPC_OPTS.wc_sessionPropose.req.ttl),
-    // };
-
     // Set the one time use receiver public key for decoding the Type 1 envelope
     await core.pairing.setReceiverPublicKey(
       topic: responseTopic,
@@ -2177,19 +2162,69 @@ class SignEngine implements ISignEngine {
       expiry: authRequestExpiry,
     );
 
-    final id = JsonRpcUtils.payloadId();
-    final fallbackId = JsonRpcUtils.payloadId();
-    Completer<OCAResponse> completer = Completer();
+    // ----- build fallback session proposal request ----- //
 
+    final fallbackMethod = MethodConstants.WC_SESSION_PROPOSE;
+    final fallbackOpts = MethodConstants.RPC_OPTS[fallbackMethod]!['req']!;
+    final fallbackExpiryTimestamp = DateTime.now().add(
+      Duration(seconds: fallbackOpts.ttl),
+    );
+    final proposalData = ProposalData(
+      id: proposalId,
+      requiredNamespaces: {},
+      optionalNamespaces: {
+        'eip155': RequiredNamespace(
+          chains: chains,
+          methods: {'personal_sign', ...requestMethods}.toList(),
+          events: EventsConstants.requiredEvents,
+        ),
+      },
+      relays: [Relay(WalletConnectConstants.RELAYER_DEFAULT_PROTOCOL)],
+      expiry: fallbackExpiryTimestamp.millisecondsSinceEpoch,
+      proposer: ConnectionMetadata(
+        publicKey: publicKey,
+        metadata: metadata,
+      ),
+      pairingTopic: pTopic,
+    );
+    final proposeRequest = WcSessionProposeRequest(
+      relays: proposalData.relays,
+      requiredNamespaces: proposalData.requiredNamespaces,
+      optionalNamespaces: proposalData.optionalNamespaces,
+      proposer: proposalData.proposer,
+    );
+    await _setProposal(proposalData.id, proposalData);
+
+    // ------------------------------------------------------- //
+
+    // Send One-Click Auth request
+    Completer<OCAResponse> completer = Completer();
     _requestOCAResponseHandler(
       id: id,
-      fallbackId: fallbackId,
       publicKey: publicKey,
       pairingTopic: pTopic,
       responseTopic: responseTopic,
-      requestParams: request,
+      request: request,
       expiry: authRequestExpiry,
       completer: completer,
+    );
+
+    // Send Session Proposal request
+    Completer<SessionData> completerFallback = Completer();
+    pendingProposals.add(
+      SessionProposalCompleter(
+        id: proposalData.id,
+        selfPublicKey: proposalData.proposer.publicKey,
+        pairingTopic: proposalData.pairingTopic,
+        requiredNamespaces: proposalData.requiredNamespaces,
+        optionalNamespaces: proposalData.optionalNamespaces,
+        completer: completerFallback,
+      ),
+    );
+    _connectResponseHandler(
+      pTopic,
+      proposeRequest,
+      proposalData.id,
     );
 
     return OCARequestResponse(
@@ -2202,12 +2237,11 @@ class SignEngine implements ISignEngine {
 
   Future<void> _requestOCAResponseHandler({
     required int id,
-    required int fallbackId,
     required String publicKey,
     required String pairingTopic,
     required String responseTopic,
-    required WcOCARequestParams requestParams,
     required int expiry,
+    required WcOCARequestParams request,
     required Completer<OCAResponse> completer,
   }) async {
     //
@@ -2216,13 +2250,12 @@ class SignEngine implements ISignEngine {
       final Map<String, dynamic> response = await core.pairing.sendRequest(
         pairingTopic,
         MethodConstants.WC_SESSION_AUTHENTICATE,
-        requestParams.toJson(),
+        request.toJson(),
         id: id,
         ttl: expiry,
       );
       result = WcOCARequestResult.fromJson(response);
     } catch (error) {
-      core.relayClient.unsubscribe(topic: responseTopic);
       final response = OCAResponse(
         id: id,
         topic: responseTopic,

--- a/lib/apis/utils/walletconnect_utils.dart
+++ b/lib/apis/utils/walletconnect_utils.dart
@@ -184,21 +184,18 @@ class WalletConnectUtils {
     required String symKey,
     required Relay relay,
     required List<List<String>>? methods,
+    int? expiry,
   }) {
     Map<String, String> params = formatRelayParams(relay);
     params['symKey'] = symKey;
     if (methods != null) {
-      params['methods'] = methods
-          .map((e) => jsonEncode(e))
-          .join(
-            ',',
-          )
-          .replaceAll(
-            '"',
-            '',
-          );
-    } else {
-      params['methods'] = '[]';
+      final uriMethods = methods.expand((e) => e).toList();
+      params['methods'] =
+          uriMethods.map((e) => jsonEncode(e)).join(',').replaceAll('"', '');
+    }
+
+    if (expiry != null) {
+      params['expiryTimestamp'] = expiry.toString();
     }
 
     return Uri(

--- a/lib/apis/web3app/web3app.dart
+++ b/lib/apis/web3app/web3app.dart
@@ -13,7 +13,6 @@ class Web3App implements IWeb3App {
     ],
     [
       MethodConstants.WC_AUTH_REQUEST,
-      MethodConstants.WC_SESSION_AUTHENTICATE,
     ]
   ];
 
@@ -365,7 +364,9 @@ class Web3App implements IWeb3App {
   Future<OCARequestResponse> authenticate({
     required OCARequestParams params,
     String? pairingTopic,
-    List<List<String>>? methods = DEFAULT_METHODS,
+    List<List<String>>? methods = const [
+      [MethodConstants.WC_SESSION_AUTHENTICATE]
+    ],
   }) async {
     try {
       return signEngine.authenticate(

--- a/lib/apis/web3app/web3app.dart
+++ b/lib/apis/web3app/web3app.dart
@@ -332,7 +332,7 @@ class Web3App implements IWeb3App {
 
   // NEW 1-CLICK AUTH METHOD
   @override
-  Event<OCAResponse> get onOCAResponse => signEngine.onOCAResponse;
+  Event<OCAuthResponse> get onOCAuthResponse => signEngine.onOCAuthResponse;
 
   @override
   IGenericStore<AuthPublicKey> get authKeys => signEngine.authKeys;

--- a/test/core_api/pairing_test.dart
+++ b/test/core_api/pairing_test.dart
@@ -39,7 +39,7 @@ void main() {
         ]);
     expect(
       Uri.decodeFull(response.toString()),
-      'wc:abc@2?relay-protocol=irn&symKey=xyz&methods=[wc_sessionPropose],[wc_authRequest,wc_authBatchRequest]',
+      'wc:abc@2?relay-protocol=irn&symKey=xyz&methods=wc_sessionPropose,wc_authRequest,wc_authBatchRequest',
     );
 
     URIParseResult parsed = WalletConnectUtils.parseUri(response);
@@ -63,7 +63,7 @@ void main() {
     );
     expect(
       Uri.decodeFull(response.toString()),
-      'wc:abc@2?relay-protocol=irn&symKey=xyz&methods=[]',
+      'wc:abc@2?relay-protocol=irn&symKey=xyz',
     );
 
     parsed = WalletConnectUtils.parseUri(response);

--- a/test/sign_api/tests/sign_connect.dart
+++ b/test/sign_api/tests/sign_connect.dart
@@ -47,14 +47,10 @@ void signConnect({
       expect(parsed.topic, response.pairingTopic);
       expect(parsed.v2Data!.relay.protocol, 'irn');
       if (clientA is IWeb3App) {
-        expect(parsed.v2Data!.methods.length, 4);
+        expect(parsed.v2Data!.methods.length, 3);
         expect(parsed.v2Data!.methods[0], MethodConstants.WC_SESSION_PROPOSE);
         expect(parsed.v2Data!.methods[1], MethodConstants.WC_SESSION_REQUEST);
         expect(parsed.v2Data!.methods[2], MethodConstants.WC_AUTH_REQUEST);
-        expect(
-          parsed.v2Data!.methods[3],
-          MethodConstants.WC_SESSION_AUTHENTICATE,
-        );
       } else {
         expect(parsed.v2Data!.methods.length, 2);
         expect(parsed.v2Data!.methods[0], MethodConstants.WC_SESSION_PROPOSE);

--- a/test/sign_api/utils/sign_client_test_wrapper.dart
+++ b/test/sign_api/utils/sign_client_test_wrapper.dart
@@ -498,7 +498,7 @@ class SignClientTestWrapper implements ISignEngine {
   Event<AuthResponse> get onAuthResponse => client.onAuthResponse;
 
   @override
-  Event<OCAResponse> get onOCAResponse => client.onOCAResponse;
+  Event<OCAuthResponse> get onOCAuthResponse => client.onOCAuthResponse;
 
   @override
   IGenericStore<String> get pairingTopics => client.pairingTopics;


### PR DESCRIPTION
# Description

Second iteration on support One-Click Auth:

- Implemented fallback mechanism to use Session Proposal when Wallet does not support OCA

### Still to be done:

- Wallet side support of OCA

## How Has This Been Tested?

- A lot of manual testing with different wallets that supports OCA. (Trust Wallet, Zerion, WC Swift Sample Wallet, WC Kotlin Sample Wallet, WC React-Wallet)

- Will add integration test when the task is completed

On video: Connection with Flutter Wallet, which does not support OCA, and Swift Wallet which does support it.

https://github.com/WalletConnect/WalletConnectFlutterV2/assets/14978705/5477a1ba-8b32-440f-aefe-4b5b826b7358


## Due Dilligence

* [ ] Breaking change
* [X] Requires a documentation update